### PR TITLE
Fix wrong urls in Dovecot Pro release 2.3.9.2-rev1 3rdparty repository documentation

### DIFF
--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/amzn/2/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/amzn/2/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
@@ -11,7 +11,7 @@ enabled=1
 # Please contact to support@open-xchange.com to get access
 [dovecot-2.3.9.2-rev1-kuromoji]
 name=Amazon Linux 2 - Atilika Kuromoji Library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/20191205/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/stable/20191205/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/amzn/2/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/amzn/2/index.rst
@@ -32,16 +32,10 @@ OX Engage Dovecot plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-promotionalmail.repo
      :language: none
 
-OX Dovecot Pro Vault plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+OX Dovecot Pro IMAP Proxy Authentication plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.repo
-     :language: none
-
-OX Dovecot Pro Command Log plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.repo
+.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.repo
      :language: none
 
 OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
@@ -50,15 +44,21 @@ OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
 .. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
      :language: none
 
+OX Dovecot Pro Command Log plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.repo
+     :language: none
+
+OX Dovecot Pro Vault plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.repo
+     :language: none
+
 OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
-     :language: none
-
-OX Dovecot Pro IMAP Proxy Authentication plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.repo
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/amzn/2/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/amzn/2/thirdparty
@@ -1,6 +1,6 @@
 [dovecot-2.3.9.2-rev1-libuv]
 name=Amazon Linux 2 - UV library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/1.9.0/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/stable/1.9.0/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1
@@ -8,7 +8,7 @@ enabled=1
 
 [dovecot-2.3.9.2-rev1-cassandra-cpp-driver]
 name=Amazon Linux 2 - DataStax C/C++ Driver for Apache Cassandra
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1
@@ -16,7 +16,7 @@ enabled=1
 
 [dovecot-2.3.9.2-rev1-libexttextcat]
 name=Amazon Linux 2 - Extextcat library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/3.4.4/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/stable/3.4.4/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1
@@ -24,7 +24,7 @@ enabled=1
 
 [dovecot-2.3.9.2-rev1-libsodium]
 name=Amazon Linux 2 - Sodium library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1
@@ -32,7 +32,7 @@ enabled=1
 
 [dovecot-2.3.9.2-rev1-icu56]
 name=Amazon Linux 2 - ICU4C 56
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/56.1/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/stable/56.1/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1
@@ -40,7 +40,7 @@ enabled=1
 
 [dovecot-2.3.9.2-rev1-clucene]
 name=Amazon Linux 2 - CLucene library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/2.3.3.4/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/stable/2.3.3.4/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1
@@ -48,7 +48,7 @@ enabled=1
 
 [dovecot-2.3.9.2-rev1-stemmer]
 name=Amazon Linux 2 - Snowball stemming C library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/1.0/AmazonLinux2
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/stable/1.0/AmazonLinux2
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 priority=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/6/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/6/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
@@ -11,7 +11,7 @@ enabled=1
 # Please contact to support@open-xchange.com to get access
 [dovecot-2.3.9.2-rev1-kuromoji]
 name=CentOS 6 - Atilika Kuromoji Library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/20191205/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/stable/20191205/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/6/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/6/index.rst
@@ -38,12 +38,6 @@ OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
      :language: none
 
-OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
-     :language: none
-
 OX Dovecot Pro Vault plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -54,6 +48,12 @@ OX Dovecot Pro Command Log plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.repo
+     :language: none
+
+OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
      :language: none
 
 OX Dovecot Pro IMAP Proxy Authentication plug-in

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/6/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/6/thirdparty
@@ -1,48 +1,48 @@
 [dovecot-2.3.9.2-rev1-libuv]
 name=CentOS 6 - UV library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/1.9.0/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/stable/1.9.0/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-cassandra-cpp-driver]
 name=CentOS 6 - DataStax C/C++ Driver for Apache Cassandra
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libexttextcat]
 name=CentOS 6 - Extextcat library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/3.4.4/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/stable/3.4.4/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libsodium]
 name=CentOS 6 - Sodium library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-icu56]
 name=CentOS 6 - ICU4C 56
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/56.1/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/stable/56.1/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-clucene]
 name=CentOS 6 - CLucene library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/2.3.3.4/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/stable/2.3.3.4/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-stemmer]
 name=CentOS 6 - Snowball stemming C library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/1.0/CentOS6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/stable/1.0/CentOS6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/7/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/7/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
@@ -11,7 +11,7 @@ enabled=1
 # Please contact to support@open-xchange.com to get access
 [dovecot-2.3.9.2-rev1-kuromoji]
 name=CentOS 7 - Atilika Kuromoji Library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/20191205/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/stable/20191205/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/7/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/7/index.rst
@@ -32,16 +32,22 @@ OX Engage Dovecot plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-promotionalmail.repo
      :language: none
 
+OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+     :language: none
+
 OX Dovecot Pro IMAP Proxy Authentication plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.repo
      :language: none
 
-OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
      :language: none
 
 OX Dovecot Pro Command Log plug-in
@@ -54,11 +60,5 @@ OX Dovecot Pro Vault plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.repo
-     :language: none
-
-OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/7/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/centos/7/thirdparty
@@ -1,48 +1,48 @@
 [dovecot-2.3.9.2-rev1-libuv]
 name=CentOS 7 - UV library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/1.9.0/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/stable/1.9.0/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-cassandra-cpp-driver]
 name=CentOS 7 - DataStax C/C++ Driver for Apache Cassandra
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libexttextcat]
 name=CentOS 7 - Extextcat library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/3.4.4/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/stable/3.4.4/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libsodium]
 name=CentOS 7 - Sodium library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-icu56]
 name=CentOS 7 - ICU4C 56
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/56.1/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/stable/56.1/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-clucene]
 name=CentOS 7 - CLucene library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/2.3.3.4/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/stable/2.3.3.4/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-stemmer]
 name=CentOS 7 - Snowball stemming C library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/1.0/CentOS7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/stable/1.0/CentOS7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/debian/buster/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/debian/buster/thirdparty
@@ -1,2 +1,2 @@
 # dovecot-2.3.9.2-rev1 Debian Buster (10.0) - DataStax C/C++ Driver for Apache Cassandra
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/DebianBuster ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/DebianBuster ./

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/debian/stretch/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/debian/stretch/index.rst
@@ -38,10 +38,10 @@ OX Dovecot Pro IMAP Proxy Authentication plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.list
      :language: none
 
-OX Dovecot Pro Vault plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.list
+.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.list
      :language: none
 
 OX Dovecot Pro Command Log plug-in
@@ -50,9 +50,9 @@ OX Dovecot Pro Command Log plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.list
      :language: none
 
-OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+OX Dovecot Pro Vault plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.list
+.. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.list
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/debian/stretch/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/debian/stretch/thirdparty
@@ -1,4 +1,4 @@
 # dovecot-2.3.9.2-rev1 Debian Stretch (9.0) - DataStax C/C++ Driver for Apache Cassandra
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/DebianStretch ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/DebianStretch ./
 # dovecot-2.3.9.2-rev1 Debian Stretch (9.0) - Sodium library
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/DebianStretch ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/DebianStretch ./

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/6/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/6/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
@@ -11,7 +11,7 @@ enabled=1
 # Please contact to support@open-xchange.com to get access
 [dovecot-2.3.9.2-rev1-kuromoji]
 name=RedHat Enterprise Linux 6 - Atilika Kuromoji Library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/20191205/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/stable/20191205/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/6/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/6/index.rst
@@ -32,6 +32,12 @@ OX Engage Dovecot plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-promotionalmail.repo
      :language: none
 
+OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+     :language: none
+
 OX Dovecot Pro IMAP Proxy Authentication plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -44,21 +50,15 @@ OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
      :language: none
 
-OX Dovecot Pro Command Log plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.repo
-     :language: none
-
 OX Dovecot Pro Vault plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.repo
      :language: none
 
-OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+OX Dovecot Pro Command Log plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+.. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.repo
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/6/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/6/thirdparty
@@ -1,48 +1,48 @@
 [dovecot-2.3.9.2-rev1-libuv]
 name=RedHat Enterprise Linux 6 - UV library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/1.9.0/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/stable/1.9.0/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-cassandra-cpp-driver]
 name=RedHat Enterprise Linux 6 - DataStax C/C++ Driver for Apache Cassandra
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libexttextcat]
 name=RedHat Enterprise Linux 6 - Extextcat library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/3.4.4/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/stable/3.4.4/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libsodium]
 name=RedHat Enterprise Linux 6 - Sodium library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-icu56]
 name=RedHat Enterprise Linux 6 - ICU4C 56
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/56.1/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/stable/56.1/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-clucene]
 name=RedHat Enterprise Linux 6 - CLucene library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/2.3.3.4/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/stable/2.3.3.4/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-stemmer]
 name=RedHat Enterprise Linux 6 - Snowball stemming C library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/1.0/RHEL6
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/stable/1.0/RHEL6
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/7/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/7/dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
@@ -11,7 +11,7 @@ enabled=1
 # Please contact to support@open-xchange.com to get access
 [dovecot-2.3.9.2-rev1-kuromoji]
 name=RedHat Enterprise Linux 7 - Atilika Kuromoji Library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/20191205/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-kuromoji/stable/20191205/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/7/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/7/index.rst
@@ -38,6 +38,18 @@ OX Dovecot Pro Full Text Search Kuromoji Tokenizer for Japanese
 .. literalinclude:: dovecot-2.3.9.2-rev1-fts-jp-kuromoji-plugin.repo
      :language: none
 
+OX Dovecot Pro IMAP Proxy Authentication plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.repo
+     :language: none
+
+OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
+     :language: none
+
 OX Dovecot Pro Command Log plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -48,17 +60,5 @@ OX Dovecot Pro Vault plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-vault-plugin.repo
-     :language: none
-
-OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.repo
-     :language: none
-
-OX Dovecot Pro IMAP Proxy Authentication plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.repo
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/7/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/rhel/7/thirdparty
@@ -1,48 +1,48 @@
 [dovecot-2.3.9.2-rev1-libuv]
 name=RedHat Enterprise Linux 7 - UV library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/1.9.0/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/stable/1.9.0/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-cassandra-cpp-driver]
 name=RedHat Enterprise Linux 7 - DataStax C/C++ Driver for Apache Cassandra
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libexttextcat]
 name=RedHat Enterprise Linux 7 - Extextcat library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/3.4.4/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libexttextcat/stable/3.4.4/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-libsodium]
 name=RedHat Enterprise Linux 7 - Sodium library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-icu56]
 name=RedHat Enterprise Linux 7 - ICU4C 56
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/56.1/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-icu56/stable/56.1/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-clucene]
 name=RedHat Enterprise Linux 7 - CLucene library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/2.3.3.4/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-clucene/stable/2.3.3.4/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1
 
 [dovecot-2.3.9.2-rev1-stemmer]
 name=RedHat Enterprise Linux 7 - Snowball stemming C library
-baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/1.0/RHEL7
+baseurl=https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-stemmer/stable/1.0/RHEL7
 gpgkey=http://software.open-xchange.com/oxbuildkey.pub
 gpgcheck=1
 enabled=1

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/bionic/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/bionic/index.rst
@@ -32,6 +32,12 @@ OX Engage Dovecot plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-promotionalmail.list
      :language: none
 
+OX Dovecot Pro IMAP Proxy Authentication plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.list
+     :language: none
+
 OX Dovecot Pro Command Log plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -48,11 +54,5 @@ OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.list
-     :language: none
-
-OX Dovecot Pro IMAP Proxy Authentication plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.list
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/bionic/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/bionic/thirdparty
@@ -1,2 +1,2 @@
 # dovecot-2.3.9.2-rev1 Ubuntu 18.04 LTS (Bionic Beaver) - DataStax C/C++ Driver for Apache Cassandra
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/Ubuntu_18.04 ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/Ubuntu_18.04 ./

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/xenial/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/xenial/index.rst
@@ -32,6 +32,18 @@ OX Engage Dovecot plug-in
 .. literalinclude:: dovecot-2.3.9.2-rev1-promotionalmail.list
      :language: none
 
+OX Dovecot Pro IMAP Proxy Authentication plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.list
+     :language: none
+
+OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.list
+     :language: none
+
 OX Dovecot Pro Vault plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -42,17 +54,5 @@ OX Dovecot Pro Command Log plug-in
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: dovecot-2.3.9.2-rev1-cmdlog-plugin.list
-     :language: none
-
-OX Dovecot Pro Pigeonhole Sieve Zimbra compability plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-pigeonhole-sieve-zimbra-compat-plugin.list
-     :language: none
-
-OX Dovecot Pro IMAP Proxy Authentication plug-in
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: dovecot-2.3.9.2-rev1-imap-proxyauth-plugin.list
      :language: none
 

--- a/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/xenial/thirdparty
+++ b/source/installation_guide/dovecot_pro_releases/dovecot-2.3.9.2-rev1/ubuntu/xenial/thirdparty
@@ -1,6 +1,6 @@
 # dovecot-2.3.9.2-rev1 Ubuntu 16.04 LTS (Xenial Xerus) - UV library
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/1.9.0/Ubuntu_16.04 ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libuv/stable/1.9.0/Ubuntu_16.04 ./
 # dovecot-2.3.9.2-rev1 Ubuntu 16.04 LTS (Xenial Xerus) - DataStax C/C++ Driver for Apache Cassandra
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/2.13.0/Ubuntu_16.04 ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-cassandra-cpp-driver/stable/2.13.0/Ubuntu_16.04 ./
 # dovecot-2.3.9.2-rev1 Ubuntu 16.04 LTS (Xenial Xerus) - Sodium library
-deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/1.0.16/Ubuntu_16.04 ./
+deb https://LDBACCOUNT:PASSWORD@software.open-xchange.com/components/dovecot-3rdparty-libsodium/stable/1.0.16/Ubuntu_16.04 ./


### PR DESCRIPTION
There was missing /stable/ part was missing in 3rdparty library paths.