### PR TITLE
Add "Edit Documentation" navigation link

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -97,6 +97,7 @@ html_theme_options = {
 #  'github_repo': 'core',
   'github_banner': False,
   'extra_nav_links': {
+    'Edit Documentation': 'https://github.com/dovecot/documentation/pulls/',
     'Repositories' : 'https://repo.dovecot.org/',
     'Download'     : 'https://dovecot.org/download.html',
   },


### PR DESCRIPTION
Lets try to help people find that this documentation exists in github and they can send pull requests. I was trying to add it also to the footer but that failed.
