### PR TITLE
configuration manual: Fix imap_command_finished's command name field name

### DIFF
--- a/source/configuration_manual/stats/index.rst
+++ b/source/configuration_manual/stats/index.rst
@@ -246,7 +246,7 @@ IMAP command statistics
    metric imap_select_no {
      event_name = imap_command_finished
      filter {
-       name = SELECT
+       cmd_name = SELECT
        tagged_reply_state = NO
      }
    }
@@ -254,7 +254,7 @@ IMAP command statistics
    metric imap_select_no_notfound {
      event_name = imap_command_finished
      filter {
-       name = SELECT
+       cmd_name = SELECT
        tagged_reply = NO*Mailbox doesn't exist:*
      }
    }


### PR DESCRIPTION
We renamed these from 'name' to 'cmd_name' back in ~November but it looks like these examples sneaked in/past us.