### PR TITLE
group_by was only added in 2.3.10

### DIFF
--- a/source/configuration_manual/stats/index.rst
+++ b/source/configuration_manual/stats/index.rst
@@ -48,6 +48,8 @@ Currently there are no statistics logged by default (but this might change). You
 Group by
 ^^^^^^^^
 
+.. versionadded:: v2.3.10
+
 The ``group_by`` metric setting allows dynamic hierarchical metric
 generation based on event fields' values.  Each field listed in the
 ``group_by`` generates one level of "sub-metrics".  These automatically


### PR DESCRIPTION
But it wasn't obvious from the docs. Now it is.