### PR TITLE
Document current event filtering

### DIFF
--- a/source/configuration_manual/event_filter.rst
+++ b/source/configuration_manual/event_filter.rst
@@ -1,0 +1,121 @@
+.. _event_filter:
+
+===============
+Event Filtering
+===============
+
+Dovecot's event support includes the ability to narrow down which events are
+processed by filtering them based on the administrator-supplied predicate.
+
+Individual events can be identified either by their name or source code
+location.  The source location of course can change between Dovecot
+versions, so it should be avoided.
+
+Regardless of the syntax used, matching is performed the same way:
+
+* Event names are compared using a case-sensitive wildcard match.  The
+  wildcards supported are ``?`` and ``*``.
+* Event location is compared in two parts: the file name is compared
+  case-sensitively, and the line number is compared as an integer.  For a
+  match to occur, the filename must match *and* the line number must either
+  match or be unspecified.
+* Event categories are compared using a "has a" relationship.  A category in
+  the filter must be present in the event for a match to occur.  Any other
+  categories on the event do not influence the match.
+* Event fields are compared using a case-insensitive wildcard match.  The
+  wildcards supported are ``?`` and ``*``.
+
+.. _event_filter_metric:
+
+Metric filter syntax
+^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: v2.3
+
+Events can be filtered inside the ``metric`` blocks (see :ref:`statistics`)
+based on the event name, source location, the categories present, and field
+values.
+
+All four use the same ``key=value`` syntax, however the semantics of each
+are slightly different.
+
+* Event name filtering uses the ``event_name`` key.  The value is matched as
+  described above.
+* Event source location filtering uses the ``source_location`` key.  The
+  value is matched as described above.
+* Event category filtering uses the ``categories`` key.  The value is a
+  space-separated list of categories *all* of which must be matched as
+  described above.
+* Event field filtering uses the field name as the key, however the
+  key-value pairs are inside the ``filter`` sub-block.  The value is matched
+  as described above.
+
+An event is said to match the filter if *all* of the specified key-value
+pairs match.
+
+For example, the following matches all events with the name
+``http_request_finished``, the source code location ``http-client.c:123``,
+the categories ``storage`` and ``imap``, the field ``user`` beginning with
+the string ``testuser``, and ``status_code`` equal to 200::
+
+   metric example_http_metric {
+     event_name = http_request_finished
+     source_location = http-client.c:123
+     categories = storage imap
+     filter {
+       user = testuser*
+       status_code = 200
+     }
+   }
+
+.. _event_filter_global:
+
+Global filter syntax
+^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: v2.3
+
+The global filter syntax is used by a handful of global settings.  In
+general, it is a boolean expression following the "OR of ANDs" pattern where
+the "OR" and "AND" operators are implied.
+
+The entire expression is a disjunction (OR) of sub-expressions separated by
+spaces.  Each sub-expression is either a comparison (see below) or a
+conjunction (AND) of comparisons grouped together by a pair of parentheses.
+
+In other words, using ``C`` to denote a comparison:
+
+* ``C`` is a single comparison
+* ``C1 C2`` is the expression "C1 OR C2"
+* ``(C1 C2)`` is the expression "C1 AND C2"
+* ``C1 (C2 C3)`` is the expression "C1 OR (C2 AND C3)"
+
+Note that any number of comparisons and sub-expressions is possible, however
+no other nesting is allowed.
+
+The comparisons can be based on the event name, source location, the
+categories present, and field values.  All four use the same ``key:value``
+syntax, however the semantics of each are slightly different.  In all cases,
+the values are matched as described in the introduction.
+
+* Event name filtering uses the ``event`` key.
+* Event source location filtering uses the ``source`` key.
+* Event category filtering uses the ``category`` key.
+* Event field filtering uses the ``field`` key, and the value uses the
+  ``fieldname=fieldvalue`` format.
+
+Additionally, there are two aliases:
+
+* ``cat:foo`` is equivalent to ``category:foo``
+* ``service:foo`` is equivalent to ``category:service:foo``
+
+An event is said to match the filter if the entire boolean expression
+evaluates as true.
+
+For example, the following matches all events with the name
+``http_request_finished`` that have the category ``imap``, as well as all
+events with the name ``imap_command_finished`` that have the field ``user``
+equal to the value ``testuser``::
+
+  (event:http_request_finished category:imap) \
+  (event:imap_command_finished field:user=testuser)

--- a/source/configuration_manual/event_filter.rst
+++ b/source/configuration_manual/event_filter.rst
@@ -32,6 +32,13 @@ Metric filter syntax
 
 .. versionadded:: v2.3
 
+.. note::
+
+   In the v2.3.12 release of Dovecot the event filtering will be completely
+   rewritten and used consistently throughout the configuration files.  The
+   new filtering language will be more expressive, and therefore any filters
+   created using the current syntax will be translatable to the new syntax.
+
 Events can be filtered inside the ``metric`` blocks (see :ref:`statistics`)
 based on the event name, source location, the categories present, and field
 values.
@@ -74,6 +81,13 @@ Global filter syntax
 ^^^^^^^^^^^^^^^^^^^^
 
 .. versionadded:: v2.3
+
+.. note::
+
+   In the v2.3.12 release of Dovecot the event filtering will be completely
+   rewritten and used consistently throughout the configuration files.  The
+   new filtering language will be more expressive, and therefore any filters
+   created using the current syntax will be translatable to the new syntax.
 
 The global filter syntax is used by a handful of global settings.  In
 general, it is a boolean expression following the "OR of ANDs" pattern where

--- a/source/configuration_manual/stats/index.rst
+++ b/source/configuration_manual/stats/index.rst
@@ -12,35 +12,43 @@ For v2.1 and v2.2 see :ref:`old_statistics`.
 
 See :ref:`list_of_events` for list of all events that can be used in statistics.
 
-Dovecot supports gathering statistics from "Events Design". Eventually all of the log messages should be events, so it will be possible to configure Dovecot to get statistics for anything that is logged. For debug messages it's possible to get statistics even if the message itself isn't logged.
+Dovecot supports gathering statistics from events (see :ref:`event_design`).
+Currently there are no statistics logged by default, and therefore they must
+be explicitly added using the ``metric`` configuration blocks.
 
-Currently there are no statistics logged by default (but this might change). You'll need to add some metrics:
+The event filter settings are the only required settings in a metric block.
+The filter specifies which events should be used when calculating the
+statistics for a given metric block.  Event filtering is described in detail
+in :ref:`event_filter_metric`.
+
+In addition to the event filter, a list of fields that are included in the
+metrics can be specified using the ``fields`` setting.  All events have a
+default "duration" field that doesn't need to be listed explicitly.
+
+Finally, the ``group_by`` metric setting can be used to dynamically generate
+sub-metrics based on fields' values.
+
+In general, the metric block has the form:
 
 .. code-block:: none
 
    metric name {
-     # Individual events can be identified either by their name or source file:line location.
-     # The source location of course can change between Dovecot versions, so it should be
-     # avoided.
-     event_name = example_event_name
-     #source_location = example.c:123
-
-     # Space-separated list of categories that must match the event (e.g. "mail" or "storage")
-     #categories =
+     ...filter related settings...
 
      # List of fields in event parameters that are included in the metrics.
-     # All events have a default "duration" field that doesn't need to be listed here.
-     #fields =
+     fields = abc def
 
-     # List of key=value pairs that must match the event. The value can contain '?' and '*' wildcards.
-     #filter {
-     #  field_key = wildcard
-     #}
+     # List of fields to group events by into auto-generated sub-metrics.
+     group_by = field another-field
+   }
 
-     # v2.3.10+
-     # List of fields to group events by into automatically generated
-     # metrics.
-     #group_by = field another-field
+For example::
+
+   metric imap_command {
+     event_name = imap_command_finished
+
+     fields = bytes_in bytes_out
+     group_by = cmd_name tagged_reply_state
    }
 
 .. _statistics_group_by:

--- a/source/configuration_manual/stats/openmetrics.rst
+++ b/source/configuration_manual/stats/openmetrics.rst
@@ -24,7 +24,6 @@ Statistics format
 By default, Dovecot exposes all configured metrics.
 If the metric name does not conform with OpenMetrics requirements, it is not exported.
 All metric names are prefixed with ``dovecot_`` and each metric is exported as ``dovecot_<metric_name>_count`` and ``dovecot_<metric_name>_duration_usecs_sum``.
-Filters are added as labels for the metric, such as ``{success="yes"}``.
 
 Dynamically generated statistics with :ref:`group_by <statistics_group_by>` will be exported too.
 The name of the base metric is used as above, and any dynamically generated sub-metrics are exported using labels.

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -2262,7 +2262,8 @@ lock_method to one of the above values.
 
 - Default: <empty>
 
-Crash after logging a matching event.
+Crash after logging a matching event.  The syntax of the filter is described
+in :ref:`event_filter_global`.
 
 For example
 
@@ -2272,8 +2273,6 @@ For example
 
 will crash any time an error is logged, which can be useful for debugging.
 
-.. todo:: Better description
-
 
 .. _setting-log_debug:
 
@@ -2282,15 +2281,14 @@ will crash any time an error is logged, which can be useful for debugging.
 
 - Default: <empty>
 
-Filter to specify what debug logging to enable.
+Filter to specify what debug logging to enable.  The syntax of the filter is
+described in :ref:`event_filter_global`.
 
 This will eventually replace ``mail_debug`` and ``auth_debug`` settings.
 
 See :ref:`setting-auth_debug`
 
 See :ref:`setting-mail_debug`
-
-.. todo:: Better description
 
 
 .. _setting-log_path:


### PR DESCRIPTION
This documents what happens right now in released versions of dovecot.  It also adds a warning that event filtering will change in the near future, but it does not contain the docs for the new language.  That'll be a separate PR.