### PR TITLE
Add missing obox/fs-auth settings

### DIFF
--- a/source/configuration_manual/authentication/proxies.rst
+++ b/source/configuration_manual/authentication/proxies.rst
@@ -51,8 +51,11 @@ addition of proxy field. The common fields to use for both proxying ways are:
 * ``destuser=s``: Tell client to use a different username when logging in.
 * ``proxy_mech=s``: Tell client to use this SASL authentication mechanism when
   logging in.
-* ``proxy_timeout``: Abort connection after this many seconds.
+* ``proxy_timeout=`` <:ref:`time_msecs`>: Abort connection after this much time has passed.
   This overrides the default :ref:`setting-login_proxy_timeout`.
+
+  .. versionchanged:: v2.3 Added support for milliseconds.
+
 * ``proxy_nopipelining``: Don't pipeline IMAP commands. This is a workaround
   for broken IMAP servers that hang otherwise.
 

--- a/source/configuration_manual/config_file/time.rst
+++ b/source/configuration_manual/config_file/time.rst
@@ -1,8 +1,8 @@
 .. _time:
 
-========
+====
 Time
-========
+====
 
 The Time value is used in Dovecot configuration to define the amount of Time
 taken by something or for doing something, such as a sending or downloading
@@ -26,3 +26,11 @@ For example:
 .. code-block:: none
 
    since 1w, since 1weeks or since 7days.
+
+.. _time_msecs:
+
+================
+Millisecond Time
+================
+
+Same as :ref:`time`, but support milliseconds precision.

--- a/source/configuration_manual/mail_location/obox/http_storages.rst
+++ b/source/configuration_manual/mail_location/obox/http_storages.rst
@@ -24,106 +24,106 @@ Additionally, because Dovecot expands %variables inside plugin section, the
 
 The parameters common to all object storages include:
 
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| Parameter                       |Description                                                                                                                    | Default      |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| absolute_timeout=<:ref:`time`>  |Maximum total time for an HTTP request to finish. Overrides all timeout configuration                                          | none         |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| absolute_timeout_msecs=<ms>     |Maximum total time for an HTTP request to finish. Overrides all timeout configuration                                          | none         |
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| addhdr=<name>:<value>           |Add the specified header to all HTTP requests.                                                                                 | none         |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.10 Can be specified multiple times.                                                                      |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| addhdrvar=<name>:<variable>     |Add the specified header to all HTTP requests and set the value to the expanded variables value.                               | none         |
-|                                 |                                                                                                                               |              |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.10                                                                                                       |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| bucket=<n>                      |Used by some backends to specify the bucket to save the data into                                                              | none         |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| bulk_delete_limit=<n>           |Number of deletes supported within the same bulk delete request. 0 disables bulk deletes. Note that this setting works only    | scality: 1000|
-|                                 |for the backends that support bulk deletion.                                                                                   | swift: 10000 |
-|                                 |                                                                                                                               | s3: 1000     |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.2.36                                                                                                       |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| bulk_delete=1                   |Set to 1 if backend supports  bulk deletes                                                                                     | v2.2: 0      |
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.2.36                                                                                                         |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| connect_timeout=<:ref:`time`>   |Timeout for establishing a TCP connection                                                                                      | timeout      |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| connect_timeout_msecs=<ms>      |Timeout for establishing a TCP connection                                                                                      | timeout_msecs|
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| delete_max_retries=<n>          |Max number of HTTP request retries for delete actions                                                                          | max_retries  |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| delete_timeout=<:ref:`time`>    |Timeout for sending a delete HTTP response                                                                                     | timeout      |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| delete_timeout_msecs=<ms>       |Timeout for sending a delete HTTP response                                                                                     | timeout_msecs|
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| loghdr=<name>                   |Headers with the given name in HTTP responses are logged as part of any error, debug or warning messages related to the HTTP   | none         |
-|                                 |request. These headers are also included in the http_request_finished event as fields prefixed with ``http_hdr_``.             |              |
-|                                 |Can be specified multiple times.                                                                                               |              |
-|                                 |.. versionadded:: 2.3.10                                                                                                       |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| max_connect_retries=<n>         |Number of connect retries                                                                                                      | 2            |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| max_retries=<n>                 |Max number of HTTP request retries                                                                                             | 4            |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| no_trace_headers=1              |Set to 1 to not add X-Dovecot-User or X-Dovecot-Session headers to HTTP request Useful to correlate object                     | 0            |
-|                                 |storage requests to AS/Dovecot sessions. If not doing correlations via log aggregation, this is safe to disable.               |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| read_max_retries=<n>            |Max number of HTTP request retries for read actions                                                                            | max_retries  |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| read_timeout=<:ref:`time`>      |Timeout for a receiving reada HTTP response                                                                                    | timeout      |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| read_timeout_msecs=<ms>         |Timeout for a receiving reada HTTP response                                                                                    | timeout_msecs|
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| reason_header_max_length=<n>    |Maximum length for X-Dovecot-Reason HTTP header If header is present, it contains information why obox operation is being done | 0            |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| slow_warn=<:ref:`time`>         |Log a warning about any HTTP request that takes longer than this time                                                          | 5s           |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| slow_warn_msecs=<ms>            |Log a warning about any HTTP request that takes longer than this many milliseconds                                             | 5000         |
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| timeout=<:ref:`time`>           |Default timeout for HTTP responses, unless overwritten by the read/write/delete_timeout_msecs                                  | 10s          |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| timeout_msecs=<ms>              |Default timeout for HTTP responses, unless overwritten by the read/write/delete_timeout_msecs                                  | 10000        |
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| write_max_retries=<n>           |Max number of HTTP request retries for write actions                                                                           | max_retries  |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| write_timeout=<:ref:`time`>     |Timeout for a write HTTP response                                                                                              | timeout      |
-|                                 |                                                                                                                               |              |
-|                                 |.. versionadded:: 2.3.0                                                                                                        |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
-| write_timeout_msecs=<ms>        |Timeout for a write HTTP response                                                                                              | timeout_msecs|
-|                                 |                                                                                                                               |              |
-|                                 |.. deprecated:: 2.3.0                                                                                                          |              |
-+---------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| Parameter                             |Description                                                                                                                    | Default      |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| absolute_timeout=<:ref:`time_msecs`>  |Maximum total time for an HTTP request to finish. Overrides all timeout configuration                                          | none         |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| absolute_timeout_msecs=<ms>           |Maximum total time for an HTTP request to finish. Overrides all timeout configuration                                          | none         |
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| addhdr=<name>:<value>                 |Add the specified header to all HTTP requests.                                                                                 | none         |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.10 Can be specified multiple times.                                                                      |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| addhdrvar=<name>:<variable>           |Add the specified header to all HTTP requests and set the value to the expanded variables value.                               | none         |
+|                                       |                                                                                                                               |              |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.10                                                                                                       |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| bucket=<n>                            |Used by some backends to specify the bucket to save the data into                                                              | none         |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| bulk_delete_limit=<n>                 |Number of deletes supported within the same bulk delete request. 0 disables bulk deletes. Note that this setting works only    | scality: 1000|
+|                                       |for the backends that support bulk deletion.                                                                                   | swift: 10000 |
+|                                       |                                                                                                                               | s3: 1000     |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.2.36                                                                                                       |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| bulk_delete=1                         |Set to 1 if backend supports  bulk deletes                                                                                     | v2.2: 0      |
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.2.36                                                                                                         |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| connect_timeout=<:ref:`time_msecs`>   |Timeout for establishing a TCP connection                                                                                      | timeout      |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| connect_timeout_msecs=<ms>            |Timeout for establishing a TCP connection                                                                                      | timeout_msecs|
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| delete_max_retries=<n>                |Max number of HTTP request retries for delete actions                                                                          | max_retries  |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| delete_timeout=<:ref:`time_msecs`>    |Timeout for sending a delete HTTP response                                                                                     | timeout      |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| delete_timeout_msecs=<ms>             |Timeout for sending a delete HTTP response                                                                                     | timeout_msecs|
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| loghdr=<name>                         |Headers with the given name in HTTP responses are logged as part of any error, debug or warning messages related to the HTTP   | none         |
+|                                       |request. These headers are also included in the http_request_finished event as fields prefixed with ``http_hdr_``.             |              |
+|                                       |Can be specified multiple times.                                                                                               |              |
+|                                       |.. versionadded:: 2.3.10                                                                                                       |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| max_connect_retries=<n>               |Number of connect retries                                                                                                      | 2            |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| max_retries=<n>                       |Max number of HTTP request retries                                                                                             | 4            |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| no_trace_headers=1                    |Set to 1 to not add X-Dovecot-User or X-Dovecot-Session headers to HTTP request Useful to correlate object                     | 0            |
+|                                       |storage requests to AS/Dovecot sessions. If not doing correlations via log aggregation, this is safe to disable.               |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| read_max_retries=<n>                  |Max number of HTTP request retries for read actions                                                                            | max_retries  |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| read_timeout=<:ref:`time_msecs`>      |Timeout for a receiving reada HTTP response                                                                                    | timeout      |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| read_timeout_msecs=<ms>               |Timeout for a receiving reada HTTP response                                                                                    | timeout_msecs|
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| reason_header_max_length=<n>          |Maximum length for X-Dovecot-Reason HTTP header If header is present, it contains information why obox operation is being done | 0            |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| slow_warn=<:ref:`time_msecs`>         |Log a warning about any HTTP request that takes longer than this time                                                          | 5s           |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| slow_warn_msecs=<ms>                  |Log a warning about any HTTP request that takes longer than this many milliseconds                                             | 5000         |
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| timeout=<:ref:`time_msecs`>           |Default timeout for HTTP responses, unless overwritten by the read/write/delete_timeout_msecs                                  | 10s          |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| timeout_msecs=<ms>                    |Default timeout for HTTP responses, unless overwritten by the read/write/delete_timeout_msecs                                  | 10000        |
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| write_max_retries=<n>                 |Max number of HTTP request retries for write actions                                                                           | max_retries  |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| write_timeout=<:ref:`time_msecs`>     |Timeout for a write HTTP response                                                                                              | timeout      |
+|                                       |                                                                                                                               |              |
+|                                       |.. versionadded:: 2.3.0                                                                                                        |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
+| write_timeout_msecs=<ms>              |Timeout for a write HTTP response                                                                                              | timeout_msecs|
+|                                       |                                                                                                                               |              |
+|                                       |.. deprecated:: 2.3.0                                                                                                          |              |
++---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
 
 Dovecot sends the following HTTP headers towards storage. They should be logged for troubleshooting purposes:
 

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -1708,7 +1708,7 @@ How many times to retry connection against a remote IMAP server?
 -----------------------------------
 
 - Default: ``1secs``
-- Values:  :ref:`time`
+- Values:  :ref:`time_msecs`
 
 How long to wait between retries against a remote IMAP server?
 
@@ -2499,6 +2499,7 @@ List of plugins to load for IMAP and POP3 login processes.
 .. versionadded:: v2.3.12
 
 - Default:``30 secs``
+- Values: :ref:`time_msecs`
 
 Timeout for login proxy failures.
 The timeout covers everything from the time connection is started until a successful login reply is received.
@@ -5293,7 +5294,7 @@ Maximum number of recipients accepted per connection.
 ------------------------------------
 
 - Default: ``5mins``
-- Values:  :ref:`time`
+- Values:  :ref:`time_msecs`
 
 Timeout for SMTP commands issued to the submission service's relay server.
 
@@ -5308,7 +5309,7 @@ The timeout is reset every time more data is being sent or received.
 ------------------------------------
 
 - Default: ``30secs``
-- Values:  :ref:`time`
+- Values:  :ref:`time_msecs`
 
 Timeout for connecting to and logging into the submission service's relay
 server.

--- a/source/settings/plugin/advanced/obox.rst
+++ b/source/settings/plugin/advanced/obox.rst
@@ -110,6 +110,18 @@ Overrides the obox username in storage. Normally the username is taken from the 
 
 Path to communicate with metacache process. Shouldn't be changed normally.
 
+.. _plugin-obox-setting_metacache_userdb:
+
+``metacache_userdb``
+--------------------
+
+- Default: ``metacache/metacache-users.db``
+- Values: :ref:`string`
+
+Path to a database which metacache process periodically writes to.
+This database is read by metacache at startup to get the latest state.
+The path is relative to :ref:`setting-state_dir`.
+This setting shouldn't be changed normally.
 
 .. _plugin-obox-setting_obox_lost_mailbox_prefix:
 

--- a/source/settings/plugin/obox-plugin.rst
+++ b/source/settings/plugin/obox-plugin.rst
@@ -175,3 +175,34 @@ How often to upload important index changes to object storage? This mainly
 means that if a backend crashes during this time, message flag changes within
 this time may be lost. A longer time can however reduce the number of index
 bundle uploads.
+
+.. _plugin-obox-setting_fs_auth_cache_dict:
+
+``fs_auth_cache_dict``
+----------------------
+
+- Default: <empty>
+- Values: :ref:`string`
+
+Dictionary URI where fs-auth process keeps authentication cache.
+This allows sharing the cache between multiple servers.
+
+.. _plugin-obox-setting_fs_auth_request_max_retries:
+
+``fs_auth_request_max_retries``
+-------------------------------
+
+- Default: 1
+- Values: :ref:`uint`
+
+If fs-auth fails to perform authentication lookup, retry the HTTP request this many times.
+
+.. _plugin-obox-setting_fs_auth_request_timeout:
+
+``fs_auth_request_timeout``
+-------------------------------
+
+- Default: 10s
+- Values: :ref:`time_msecs`
+
+Absolute HTTP request timeout for authentication lookups.


### PR DESCRIPTION
Jira: DOV-4028

Also fixes several settings to use time_msecs type rather than just time.
