### PR TITLE
Update master_users.rst

### DIFF
--- a/source/configuration_manual/authentication/master_users.rst
+++ b/source/configuration_manual/authentication/master_users.rst
@@ -167,7 +167,7 @@ exists and get other extra fields.
    # master password passdb
    passdb {
       driver = static
-      default_fields = password=master-password
+      args = password=master-password
       result_success = continue
    }
    # primary passdb


### PR DESCRIPTION
Prior sample config for master password actually caused the master password to be blank (!), a rather dangerous configuration.