### PR TITLE
Fix typo in userdb documentation (Passdb -> Userdb) and - to No.

### DIFF
--- a/source/configuration_manual/authentication/user_databases_userdb.rst
+++ b/source/configuration_manual/authentication/user_databases_userdb.rst
@@ -16,11 +16,11 @@ include:
 * Overriding settings for the user (almost any setting can be overridden)
 
 ===========================   ================   ===============
-Passdb lookups are done by:   Dovecot Director   Dovecot Backend
+Userdb lookups are done by:   Dovecot Director   Dovecot Backend
 ===========================   ================   ===============
-IMAP & POP3 logins            ``-``              Yes
-LMTP mail delivery            ``-``              Yes
-doveadm commands              ``-``              Yes
+IMAP & POP3 logins            No                 Yes
+LMTP mail delivery            No                 Yes
+doveadm commands              No                 Yes
 ===========================   ================   ===============
 
 The user database lookup can return these fields:


### PR DESCRIPTION
Fixed typo, also changed - to No for clarity.