### PR TITLE
settings/fts: Add missing escape to special-use \Trash

### DIFF
--- a/source/settings/plugin/fts-plugin.rst
+++ b/source/settings/plugin/fts-plugin.rst
@@ -29,9 +29,9 @@ See :ref:`plugin-fts-setting-fts_autoindex_max_recent_msgs`
 - Default: ``0`` (ignore)
 - Values: :ref:`uint`
 
-To exclude infrequently accessed mailboxes from automatic indexing, set this value to the maximum number of \Recent flagged messages that exist in the mailbox.
+To exclude infrequently accessed mailboxes from automatic indexing, set this value to the maximum number of ``\Recent`` flagged messages that exist in the mailbox.
 
-Mailboxes with more flagged \Recent messages than this value will not be autoindexed, even though they get deliveries or appends.
+Mailboxes with more flagged ``\Recent`` messages than this value will not be autoindexed, even though they get deliveries or appends.
 This is useful for, e.g., inactive Junk folders.
 
 Any folders excluded from automatic indexing will still be indexed, if a search on them is performed.
@@ -54,7 +54,7 @@ Example Setting:
 
 To exclude a mailbox from automatic indexing, it can be listed in this setting.
 To exclude additional mailboxes, add sequential numbers to the end of the plugin name.
-It's possible to use either mailbox names or refer to them using special-use flags (e.g. \Trash)
+It's possible to use either mailbox names or refer to them using special-use flags (e.g. ``\Trash``)
 
 For example::
 


### PR DESCRIPTION
The '\\' needs to be visible.