### PR TITLE
admin_manual: Rename "rebalancing directors" to "rebalancing backends"

### DIFF
--- a/source/admin_manual/director/index.rst
+++ b/source/admin_manual/director/index.rst
@@ -17,6 +17,6 @@ Directors can be managed using the ``doveadm director`` commands. See ``doveadm 
 
    director_disaster_recovery
 
-   rebalancing_directors
+   rebalancing_backends
 
    director_capacity

--- a/source/admin_manual/director/rebalancing_backends.rst
+++ b/source/admin_manual/director/rebalancing_backends.rst
@@ -1,8 +1,8 @@
-.. _rebalancing_director:
+.. _rebalancing_director_backends:
 
-======================
-Rebalancing Directors
-======================
+====================
+Rebalancing Backends
+====================
 
 Sometimes with long lasting IMAP connections you might end up in situation where you need to increase the amount of backends due to increased load. 
 


### PR DESCRIPTION
It's a bit confusing since the director servers themselves aren't being rebalanced.