### PR TITLE
Update Metrics documentation

### DIFF
--- a/source/configuration_manual/stats/index.rst
+++ b/source/configuration_manual/stats/index.rst
@@ -91,15 +91,15 @@ This example configuration will generate statistics for each IMAP command.
 The first "sub-metric" level is based on the IMAP command name, and the
 second (and in this example final) level is based on the tagged reply.  For
 example, a ``SELECT`` IMAP command that succeeded (in other words, it had an
-``OK`` reply) will generate the metric ``imap_command_select_ok``.
+``OK`` reply) will generate the metric ``imap_command_SELECT_ok``.
 
 In addition to the final level metric, all intermediate level metrics are
 generated as well.  For example, the same ``SELECT`` IMAP command will
 generate all of the following metrics:
 
  - ``imap_command``
- - ``imap_command_select``
- - ``imap_command_select_ok``
+ - ``imap_command_SELECT``
+ - ``imap_command_SELECT_ok``
 
 Note: While the top level metrics (e.g., ``imap_command`` above) are
 generated at start up, all ``group_by`` metrics are generated dynamically
@@ -155,12 +155,12 @@ This will generate metric names of the format
 command name, and ``{min}`` and ``{max}`` are the range bounds.  Therefore,
 for a ``SELECT`` IMAP command, the possible generated metric names are:
 
-* ``imap_command_select_ninf_10``
-* ``imap_command_select_11_100``
-* ``imap_command_select_101_1000``
-* ``imap_command_select_1001_10000``
-* ``imap_command_select_10001_100000``
-* ``imap_command_select_100001_inf``
+* ``imap_command_SELECT_ninf_10``
+* ``imap_command_SELECT_11_100``
+* ``imap_command_SELECT_101_1000``
+* ``imap_command_SELECT_1001_10000``
+* ``imap_command_SELECT_10001_100000``
+* ``imap_command_SELECT_100001_inf``
 
 Note: Since the metric names cannot contain -, the string ``ninf`` is used
 to denote negative infinity.
@@ -172,7 +172,7 @@ Finally, because all intermediate level metrics are generated as well.  The
 above example, will also generate all of the following metrics:
 
  - ``imap_command``
- - ``imap_command_select``
+ - ``imap_command_SELECT``
 
 `linear`
 --------

--- a/source/configuration_manual/stats/openmetrics.rst
+++ b/source/configuration_manual/stats/openmetrics.rst
@@ -23,152 +23,173 @@ Statistics format
 
 By default, Dovecot exposes all configured metrics.
 If the metric name does not conform with OpenMetrics requirements, it is not exported.
-All metric names are prefixed with ``dovecot_`` and each metric is exported as ``dovecot_<metric_name>_count`` and ``dovecot_<metric_name>_duration_usecs_sum``.
+All metric names are prefixed with ``dovecot_`` and each non-histogram metric is exported as ``dovecot_<metric_name>_total`` and ``dovecot_<metric_name>_duration_seconds_total``.
+
+.. versionchanged:: 2.3.13 Automatically generated ``dovecot_<metric_name>_count`` and ``dovecot_<metric_name>_duration_usecs_sum`` metrics renamed to the format above.
 
 Dynamically generated statistics with :ref:`group_by <statistics_group_by>` will be exported too.
 The name of the base metric is used as above, and any dynamically generated sub-metrics are exported using labels.
 Quantized sub-metrics are exported as histograms.
+Histgorams are exported as ``dovecot_<metric_name>_bucket`` with corresponding labels. Each histogram will have
+an automatically generated ``_sum`` (specifying sum of all values in quantiles) and ``_count`` (total number of samples in the quantiles) metrics.
 
-Dovecot will also export version and uptime as special metrics even if nothing is configured.
-These are called ``dovecot_stats_uptime_seconds`` and ``dovecot_build_info``.
+.. versionchanged:: 2.3.13 Histogram metrics will no longer have "histogram" in their name added by dovecot.
+.. versionchanged:: 2.3.13 The separate metrics of type counter for total number and total duarion (previosuly ``dovecot_<metric_name>_count`` and ``dovecot_<metric_name>_duration_usecs_sum``) are no longer exported for histograms.
+
+Dovecot will also export version information and startup time as special metrics even if nothing is configured.
+These are called ``dovecot_build_info`` and ``process_start_time_seconds``.
+
+.. versionchanged:: 2.3.13 Uptime metric (``dovecot_stats_uptime_seconds``) is dropped, dovecot exports timestamp of service start in ``process_start_time_seconds``.
+
+.. versionchanged:: 2.3.13 Metric timestamps are dropped.
 
 Example
 =======
 
+Bellow is an excerpt of an example dovecot configuration file that defines
+a set of metrics.
+
 ::
 
-  # HELP dovecot_stats_uptime_seconds Dovecot stats service uptime
-  # TYPE dovecot_stats_uptime_seconds counter
-  dovecot_stats_uptime_seconds 2 1587736228592
+  metric client_connections {
+    filter = event=client_connection_finished
+  }
 
-  # HELP dovecot_build_info Dovecot build information
-  # TYPE dovecot_build_info untyped
-  dovecot_build_info{version="2.4.devel",revision="72d000b2f"} 1 1587736228592
+  metric auth_success {
+    filter = (event=auth_request_finished AND success=yes)
+  }
 
-  # HELP dovecot_client_connections_count Total number
-  # TYPE dovecot_client_connections_count counter
-  dovecot_client_connections_count 0 1587736228592
+  metric imap_command {
+    filter = event=imap_command_finished
+    group_by = cmd_name tagged_reply_state
+  }
 
-  # HELP dovecot_client_connections_duration_usecs_sum Duration
-  # TYPE dovecot_client_connections_duration_usecs_sum counter
-  dovecot_client_connections_duration_usecs_sum 0 1587736228592
+  metric smtp_command {
+    filter = event=smtp_server_command_finished
+    group_by = cmd_name status_code duration:exponential:1:5:10
+  }
 
-  # HELP dovecot_auth_success_count Total number
-  # TYPE dovecot_auth_success_count counter
-  dovecot_auth_success_count{success="yes"} 451 1587736228592
+  metric mail_delivery {
+    filter = event=mail_delivery_finished
+    group_by = duration:exponential:1:5:10
+  }
 
-  # HELP dovecot_auth_success_duration_usecs_sum Duration
-  # TYPE dovecot_auth_success_duration_usecs_sum counter
-  dovecot_auth_success_duration_usecs_sum{success="yes"} 48726 1587736228592
 
-  # HELP dovecot_imap_command_count Total number
-  # TYPE dovecot_imap_command_count counter
-  dovecot_imap_command_count{cmd_name="LIST"} 242 1587736228592
-  dovecot_imap_command_count{cmd_name="LIST",tagged_reply_state="OK"} 242 1587736228592
-  dovecot_imap_command_count{cmd_name="SELECT"} 450 1587736228592
-  dovecot_imap_command_count{cmd_name="SELECT",tagged_reply_state="OK"} 450 1587736228592
-  dovecot_imap_command_count{cmd_name="STATUS"} 208 1587736228592
-  dovecot_imap_command_count{cmd_name="STATUS",tagged_reply_state="OK"} 208 1587736228592
-  dovecot_imap_command_count{cmd_name="APPEND"} 240 1587736228592
-  dovecot_imap_command_count{cmd_name="APPEND",tagged_reply_state="OK"} 240 1587736228592
-  dovecot_imap_command_count{cmd_name="LOGOUT"} 451 1587736228592
-  dovecot_imap_command_count{cmd_name="LOGOUT",tagged_reply_state="OK"} 451 1587736228592
-  dovecot_imap_command_count{cmd_name="UID FETCH"} 447 1587736228592
-  dovecot_imap_command_count{cmd_name="UID FETCH",tagged_reply_state="OK"} 447 1587736228592
-  dovecot_imap_command_count{cmd_name="FETCH"} 1088 1587736228592
-  dovecot_imap_command_count{cmd_name="FETCH",tagged_reply_state="OK"} 1088 1587736228592
-  dovecot_imap_command_count{cmd_name="EXPUNGE"} 447 1587736228592
-  dovecot_imap_command_count{cmd_name="EXPUNGE",tagged_reply_state="OK"} 447 1587736228592
-  dovecot_imap_command_count{cmd_name="STORE"} 409 1587736228592
-  dovecot_imap_command_count{cmd_name="STORE",tagged_reply_state="OK"} 409 1587736228592
+And the following is a sample exported data with such metrics configuration:
 
-  # HELP dovecot_imap_command_duration_usecs_sum Duration
-  # TYPE dovecot_imap_command_duration_usecs_sum counter
-  dovecot_imap_command_duration_usecs_sum{cmd_name="LIST"} 102977 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="LIST",tagged_reply_state="OK"} 102977 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="SELECT"} 208810 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="SELECT",tagged_reply_state="OK"} 208810 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="STATUS"} 131472 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="STATUS",tagged_reply_state="OK"} 131472 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="APPEND"} 285793 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="APPEND",tagged_reply_state="OK"} 285793 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="LOGOUT"} 22966 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="LOGOUT",tagged_reply_state="OK"} 22966 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="UID FETCH"} 178660 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="UID FETCH",tagged_reply_state="OK"} 178660 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="FETCH"} 1209618 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="FETCH",tagged_reply_state="OK"} 1209618 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="EXPUNGE"} 256421 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="EXPUNGE",tagged_reply_state="OK"} 256421 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="STORE"} 382000 1587736228592
-  dovecot_imap_command_duration_usecs_sum{cmd_name="STORE",tagged_reply_state="OK"} 382000 1587736228592
+::
 
-  # HELP dovecot_smtp_command_count Total number
-  # TYPE dovecot_smtp_command_count counter
-  dovecot_smtp_command_count{cmd_name="LHLO"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="LHLO",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="MAIL"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="MAIL",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="RCPT"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="RCPT",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="DATA"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="DATA",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="QUIT"} 1 1587736228592
-  dovecot_smtp_command_count{cmd_name="QUIT",status_code="221"} 1 1587736228592
-
-  # HELP dovecot_smtp_command_duration_usecs_sum Duration
-  # TYPE dovecot_smtp_command_duration_usecs_sum counter
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="LHLO"} 70 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="LHLO",status_code="250"} 70 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="MAIL"} 55 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="MAIL",status_code="250"} 55 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="RCPT"} 327 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="RCPT",status_code="250"} 327 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="DATA"} 2371 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="DATA",status_code="250"} 2371 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="QUIT"} 22 1587736228592
-  dovecot_smtp_command_duration_usecs_sum{cmd_name="QUIT",status_code="221"} 22 1587736228592
-
-  # HELP dovecot_smtp_command_histogram Histogram
-  # TYPE dovecot_smtp_command_histogram histogram
-  dovecot_smtp_command_histogram_bucket{cmd_name="LHLO",status_code="250",le="10"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="LHLO",status_code="250",le="100"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="LHLO",status_code="250",le="1000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="LHLO",status_code="250",le="10000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="LHLO",status_code="250",le="100000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="LHLO",status_code="250",le="+Inf"} 1 1587736228592
-  dovecot_smtp_command_histogram_sum{cmd_name="LHLO",status_code="250"} 70 1587736228592
-  dovecot_smtp_command_histogram_count{cmd_name="LHLO",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="MAIL",status_code="250",le="10"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="MAIL",status_code="250",le="100"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="MAIL",status_code="250",le="1000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="MAIL",status_code="250",le="10000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="MAIL",status_code="250",le="100000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="MAIL",status_code="250",le="+Inf"} 1 1587736228592
-  dovecot_smtp_command_histogram_sum{cmd_name="MAIL",status_code="250"} 55 1587736228592
-  dovecot_smtp_command_histogram_count{cmd_name="MAIL",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="RCPT",status_code="250",le="10"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="RCPT",status_code="250",le="100"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="RCPT",status_code="250",le="1000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="RCPT",status_code="250",le="10000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="RCPT",status_code="250",le="100000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="RCPT",status_code="250",le="+Inf"} 1 1587736228592
-  dovecot_smtp_command_histogram_sum{cmd_name="RCPT",status_code="250"} 327 1587736228592
-  dovecot_smtp_command_histogram_count{cmd_name="RCPT",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="DATA",status_code="250",le="10"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="DATA",status_code="250",le="100"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="DATA",status_code="250",le="1000"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="DATA",status_code="250",le="10000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="DATA",status_code="250",le="100000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="DATA",status_code="250",le="+Inf"} 1 1587736228592
-  dovecot_smtp_command_histogram_sum{cmd_name="DATA",status_code="250"} 2371 1587736228592
-  dovecot_smtp_command_histogram_count{cmd_name="DATA",status_code="250"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="QUIT",status_code="221",le="10"} 0 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="QUIT",status_code="221",le="100"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="QUIT",status_code="221",le="1000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="QUIT",status_code="221",le="10000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="QUIT",status_code="221",le="100000"} 1 1587736228592
-  dovecot_smtp_command_histogram_bucket{cmd_name="QUIT",status_code="221",le="+Inf"} 1 1587736228592
-  dovecot_smtp_command_histogram_sum{cmd_name="QUIT",status_code="221"} 22 1587736228592
-  dovecot_smtp_command_histogram_count{cmd_name="QUIT",status_code="221"} 1 1587736228592
+  # HELP process_start_time_seconds Timestamp of service start
+  # TYPE process_start_time_seconds gauge
+  process_start_time_seconds 1606393397
+  # HELP dovecot_build Dovecot build information
+  # TYPE dovecot_build info
+  dovecot_build_info{version="2.4.devel",revision="38ecc424a"} 1
+  # HELP dovecot_client_connections Total number of all events of this kind
+  # TYPE dovecot_client_connections counter
+  dovecot_client_connections_total 0
+  # HELP dovecot_client_connections_duration_seconds Total duration of all events of this kind
+  # TYPE dovecot_client_connections_duration_seconds counter
+  dovecot_client_connections_duration_seconds_total 0.000000
+  # HELP dovecot_auth_success Total number of all events of this kind
+  # TYPE dovecot_auth_success counter
+  dovecot_auth_success_total 892
+  # HELP dovecot_auth_success_duration_seconds Total duration of all events of this kind
+  # TYPE dovecot_auth_success_duration_seconds counter
+  dovecot_auth_success_duration_seconds_total 0.085479
+  # HELP dovecot_imap_command Total number of all events of this kind
+  # TYPE dovecot_imap_command counter
+  dovecot_imap_command_total{cmd_name="LIST"} 423
+  dovecot_imap_command_total{cmd_name="LIST",tagged_reply_state="OK"} 423
+  dovecot_imap_command_total{cmd_name="STATUS"} 468
+  dovecot_imap_command_total{cmd_name="STATUS",tagged_reply_state="OK"} 468
+  dovecot_imap_command_total{cmd_name="SELECT"} 890
+  dovecot_imap_command_total{cmd_name="SELECT",tagged_reply_state="OK"} 890
+  dovecot_imap_command_total{cmd_name="APPEND"} 449
+  dovecot_imap_command_total{cmd_name="APPEND",tagged_reply_state="OK"} 449
+  dovecot_imap_command_total{cmd_name="LOGOUT"} 892
+  dovecot_imap_command_total{cmd_name="LOGOUT",tagged_reply_state="OK"} 892
+  dovecot_imap_command_total{cmd_name="UID FETCH"} 888
+  dovecot_imap_command_total{cmd_name="UID FETCH",tagged_reply_state="OK"} 888
+  dovecot_imap_command_total{cmd_name="FETCH"} 2148
+  dovecot_imap_command_total{cmd_name="FETCH",tagged_reply_state="OK"} 2148
+  dovecot_imap_command_total{cmd_name="STORE"} 794
+  dovecot_imap_command_total{cmd_name="STORE",tagged_reply_state="OK"} 794
+  dovecot_imap_command_total{cmd_name="EXPUNGE"} 888
+  dovecot_imap_command_total{cmd_name="EXPUNGE",tagged_reply_state="OK"} 888
+  dovecot_imap_command_count 7840
+  # HELP dovecot_imap_command_duration_seconds Total duration of all events of this kind
+  # TYPE dovecot_imap_command_duration_seconds counter
+  dovecot_imap_command_duration_seconds_total{cmd_name="LIST"} 0.099115
+  dovecot_imap_command_duration_seconds_total{cmd_name="LIST",tagged_reply_state="OK"} 0.099115
+  dovecot_imap_command_duration_seconds_total{cmd_name="STATUS"} 0.161195
+  dovecot_imap_command_duration_seconds_total{cmd_name="STATUS",tagged_reply_state="OK"} 0.161195
+  dovecot_imap_command_duration_seconds_total{cmd_name="SELECT"} 0.184907
+  dovecot_imap_command_duration_seconds_total{cmd_name="SELECT",tagged_reply_state="OK"} 0.184907
+  dovecot_imap_command_duration_seconds_total{cmd_name="APPEND"} 0.273893
+  dovecot_imap_command_duration_seconds_total{cmd_name="APPEND",tagged_reply_state="OK"} 0.273893
+  dovecot_imap_command_duration_seconds_total{cmd_name="LOGOUT"} 0.033494
+  dovecot_imap_command_duration_seconds_total{cmd_name="LOGOUT",tagged_reply_state="OK"} 0.033494
+  dovecot_imap_command_duration_seconds_total{cmd_name="UID FETCH"} 0.181319
+  dovecot_imap_command_duration_seconds_total{cmd_name="UID FETCH",tagged_reply_state="OK"} 0.181319
+  dovecot_imap_command_duration_seconds_total{cmd_name="FETCH"} 1.169456
+  dovecot_imap_command_duration_seconds_total{cmd_name="FETCH",tagged_reply_state="OK"} 1.169456
+  dovecot_imap_command_duration_seconds_total{cmd_name="STORE"} 0.368621
+  dovecot_imap_command_duration_seconds_total{cmd_name="STORE",tagged_reply_state="OK"} 0.368621
+  dovecot_imap_command_duration_seconds_total{cmd_name="EXPUNGE"} 0.247657
+  dovecot_imap_command_duration_seconds_total{cmd_name="EXPUNGE",tagged_reply_state="OK"} 0.247657
+  dovecot_imap_command_duration_seconds_sum 2.719657
+  # HELP dovecot_smtp_command Histogram
+  # TYPE dovecot_smtp_command histogram
+  dovecot_smtp_command_bucket{cmd_name="LHLO",status_code="250",le="10"} 0
+  dovecot_smtp_command_bucket{cmd_name="LHLO",status_code="250",le="100"} 1
+  dovecot_smtp_command_bucket{cmd_name="LHLO",status_code="250",le="1000"} 1
+  dovecot_smtp_command_bucket{cmd_name="LHLO",status_code="250",le="10000"} 1
+  dovecot_smtp_command_bucket{cmd_name="LHLO",status_code="250",le="100000"} 1
+  dovecot_smtp_command_bucket{cmd_name="LHLO",status_code="250",le="+Inf"} 1
+  dovecot_smtp_command_sum{cmd_name="LHLO",status_code="250"} 0.000020
+  dovecot_smtp_command_count{cmd_name="LHLO",status_code="250"} 1
+  dovecot_smtp_command_bucket{cmd_name="MAIL",status_code="250",le="10"} 0
+  dovecot_smtp_command_bucket{cmd_name="MAIL",status_code="250",le="100"} 1
+  dovecot_smtp_command_bucket{cmd_name="MAIL",status_code="250",le="1000"} 1
+  dovecot_smtp_command_bucket{cmd_name="MAIL",status_code="250",le="10000"} 1
+  dovecot_smtp_command_bucket{cmd_name="MAIL",status_code="250",le="100000"} 1
+  dovecot_smtp_command_bucket{cmd_name="MAIL",status_code="250",le="+Inf"} 1
+  dovecot_smtp_command_sum{cmd_name="MAIL",status_code="250"} 0.000021
+  dovecot_smtp_command_count{cmd_name="MAIL",status_code="250"} 1
+  dovecot_smtp_command_bucket{cmd_name="RCPT",status_code="250",le="10"} 0
+  dovecot_smtp_command_bucket{cmd_name="RCPT",status_code="250",le="100"} 0
+  dovecot_smtp_command_bucket{cmd_name="RCPT",status_code="250",le="1000"} 1
+  dovecot_smtp_command_bucket{cmd_name="RCPT",status_code="250",le="10000"} 1
+  dovecot_smtp_command_bucket{cmd_name="RCPT",status_code="250",le="100000"} 1
+  dovecot_smtp_command_bucket{cmd_name="RCPT",status_code="250",le="+Inf"} 1
+  dovecot_smtp_command_sum{cmd_name="RCPT",status_code="250"} 0.000195
+  dovecot_smtp_command_count{cmd_name="RCPT",status_code="250"} 1
+  dovecot_smtp_command_bucket{cmd_name="DATA",status_code="250",le="10"} 0
+  dovecot_smtp_command_bucket{cmd_name="DATA",status_code="250",le="100"} 0
+  dovecot_smtp_command_bucket{cmd_name="DATA",status_code="250",le="1000"} 0
+  dovecot_smtp_command_bucket{cmd_name="DATA",status_code="250",le="10000"} 1
+  dovecot_smtp_command_bucket{cmd_name="DATA",status_code="250",le="100000"} 1
+  dovecot_smtp_command_bucket{cmd_name="DATA",status_code="250",le="+Inf"} 1
+  dovecot_smtp_command_sum{cmd_name="DATA",status_code="250"} 0.001249
+  dovecot_smtp_command_count{cmd_name="DATA",status_code="250"} 1
+  dovecot_smtp_command_bucket{cmd_name="QUIT",status_code="221",le="10"} 1
+  dovecot_smtp_command_bucket{cmd_name="QUIT",status_code="221",le="100"} 1
+  dovecot_smtp_command_bucket{cmd_name="QUIT",status_code="221",le="1000"} 1
+  dovecot_smtp_command_bucket{cmd_name="QUIT",status_code="221",le="10000"} 1
+  dovecot_smtp_command_bucket{cmd_name="QUIT",status_code="221",le="100000"} 1
+  dovecot_smtp_command_bucket{cmd_name="QUIT",status_code="221",le="+Inf"} 1
+  dovecot_smtp_command_sum{cmd_name="QUIT",status_code="221"} 0.000010
+  dovecot_smtp_command_count{cmd_name="QUIT",status_code="221"} 1
+  # HELP dovecot_mail_delivery Histogram
+  # TYPE dovecot_mail_delivery histogram
+  dovecot_mail_delivery_bucket{le="10"} 0
+  dovecot_mail_delivery_bucket{le="100"} 0
+  dovecot_mail_delivery_bucket{le="1000"} 1
+  dovecot_mail_delivery_bucket{le="10000"} 1
+  dovecot_mail_delivery_bucket{le="100000"} 1
+  dovecot_mail_delivery_bucket{le="+Inf"} 1
+  dovecot_mail_delivery_sum 0.000656
+  dovecot_mail_delivery_count 1
+  # EOF
 


### PR DESCRIPTION
- Conventions used in OpenMetrics exposition
- Upper case for commands used in auto-generated grouped metrics in stats