### PR TITLE
upgrading: Merge v2.3.x upgrades into one page

### DIFF
--- a/source/installation_guide/upgrading/from-2.3-to-2.3.12.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-2.3.12.rst
@@ -1,4 +1,0 @@
-Upgrading Dovecot v2.3.x to v2.3.12
-===================================
-
- * Event filter syntax has changed, see :ref:`event_filter`.

--- a/source/installation_guide/upgrading/from-2.3-to-2.3.x.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-2.3.x.rst
@@ -1,0 +1,9 @@
+Upgrading Dovecot v2.3.x to v2.3.7
+==================================
+
+ * fts-solr: The obsolete break-imap-search parameter is no longer recognized
+
+Upgrading Dovecot v2.3.x to v2.3.12
+===================================
+
+ * Event filter syntax has changed, see :ref:`event_filter`.

--- a/source/installation_guide/upgrading/from-2.3-to-2.3.x.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-2.3.x.rst
@@ -7,3 +7,12 @@ Upgrading Dovecot v2.3.x to v2.3.12
 ===================================
 
  * Event filter syntax has changed, see :ref:`event_filter`.
+
+Upgrading Dovecot v2.3.x to v2.3.14
+====================================
+
+ * Removed cydir storage format. It was never intended for production use.
+ * Removed snarf plugin. It was for UW-IMAP's mbox compatibility, which is unlikely to be needed anymore.
+ * Removed mail_filter plugin. It was mainly intended as an example plugin.
+ * Removed autocreate plugin. Use `mailbox { auto }` :ref:`mailbox_settings` instead.
+ * Removed expire plugin. Use `mailbox { autoexpunge }` :ref:`mailbox_settings` instead.

--- a/source/installation_guide/upgrading/from-2.3-to-2.4.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-2.4.rst
@@ -1,5 +1,0 @@
-Upgrading Dovecot v2.3 to v2.4
-==============================
-
- * fts-solr: The obsolete break-imap-search parameter is no longer recognized
-

--- a/source/installation_guide/upgrading/index.rst
+++ b/source/installation_guide/upgrading/index.rst
@@ -14,8 +14,7 @@ And that may be a good thing, since it can expose problems which could otherwise
 .. toctree::
    :maxdepth: 1
 
-   from-2.3-to-2.4
-   from-2.3-to-2.3.12
+   from-2.3-to-2.3.x
    from-2.2-to-2.3
    from-2.1-to-2.2
    from-2.0-to-2.1


### PR DESCRIPTION
Also break-imap-search was removed in v2.3.7, not v2.4.