### PR TITLE
configuration_manual: http_storages: Fix wrongly rendered versionadded

### DIFF
--- a/source/configuration_manual/mail_location/obox/http_storages.rst
+++ b/source/configuration_manual/mail_location/obox/http_storages.rst
@@ -77,6 +77,7 @@ The parameters common to all object storages include:
 | loghdr=<name>                         |Headers with the given name in HTTP responses are logged as part of any error, debug or warning messages related to the HTTP   | none         |
 |                                       |request. These headers are also included in the http_request_finished event as fields prefixed with ``http_hdr_``.             |              |
 |                                       |Can be specified multiple times.                                                                                               |              |
+|                                       |                                                                                                                               |              |
 |                                       |.. versionadded:: 2.3.10                                                                                                       |              |
 +---------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+--------------+
 | max_connect_retries=<n>               |Number of connect retries                                                                                                      | 2            |


### PR DESCRIPTION
In the parameters table loghdr's ``versionadded`` is not rendered correctly https://doc.dovecot.org/configuration_manual/mail_location/obox/http_storages/index.html 