### PR TITLE
Wiki conversion cleanup

### DIFF
--- a/source/admin_manual/importing_mailboxes.rst
+++ b/source/admin_manual/importing_mailboxes.rst
@@ -4,7 +4,7 @@
 Importing mailboxes
 ===================
 
-For importing mails, dovecot has `doveadm import <https://wiki2.dovecot.org/Tools/Doveadm/Import>`_ command.
+For importing mails, dovecot has `doveadm import <https://wiki.dovecot.org/Tools/Doveadm/Import>`_ command.
 
 .. warning::
 

--- a/source/admin_manual/mailbox_formats/maildir.rst
+++ b/source/admin_manual/mailbox_formats/maildir.rst
@@ -128,7 +128,7 @@ Dovecot supports reading a few fields from the ``<base filename>``:
 
 * ``,S=<size>``: ``<size>`` contains the file size. Getting the size from the
   filename avoids doing a system ``stat()`` call, which may improve the
-  performance. This is especially useful with `Maildir++ quota`_.
+  performance. This is especially useful with :ref:`quota_backend_maildir`.
 * ``,W=<vsize>``: ``<vsize>`` contains the file's RFC822.SIZE, i.e., the file
   size with linefeeds being CR+LF characters. If the message was stored with
   CR+LF linefeeds, ``<size>`` and ``<vsize>`` are the same. Setting this may
@@ -140,8 +140,6 @@ A Maildir filename with those fields would look something like:
 .. code-block:: none
 
   1035478339.27041_118.foo.org,S=1000,W=1030:2,S
-
-.. _`Maildir++ quota`: https://wiki.dovecot.org/Quota/Maildir
 
 Usage of Timestamps
 -------------------
@@ -298,10 +296,8 @@ look like:
 Filesystem Permissions
 ----------------------
 
-See `Shared Mailboxes Permissions`_ for how permissions are set for newly
-created files and directories.
-
-.. _`Shared Mailboxes Permissions`: https://wiki.dovecot.org/SharedMailboxes/Permissions
+See :ref:`Shared Mailboxes Permissions <admin_manual_permissions_in_shared_mailboxes>`
+for how permissions are set for newly created files and directories.
 
 Issues with the Specification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/admin_manual/pigeonhole_managesieve_server.rst
+++ b/source/admin_manual/pigeonhole_managesieve_server.rst
@@ -5,16 +5,16 @@ Pigeonhole ManageSieve Server
 ==============================
 
 The :ref:`Pigeonhole project <sieve>` provides `Sieve
-<http://sieve.info/>`__ support for Dovecot, which allows users to filter
+<http://sieve.info/>`_ support for Dovecot, which allows users to filter
 incoming messages by writing scripts specified in the Sieve language (`RFC
-5228 <https://tools.ietf.org/html/rfc5228>`__).
+5228 <https://tools.ietf.org/html/rfc5228>`_).
 The Pigeonhole ManageSieve service is used to manage a user's Sieve
 script collection. It has the following advantages over doing it directly via
 filesystem:
 
 * No need to let users log in via FTP/SFTP/etc, which could be difficult
   especially with virtual users.
-* ManageSieve is a `standard protocol <https://tools.ietf.org/html/rfc5804>`__,
+* ManageSieve is a `standard protocol <https://tools.ietf.org/html/rfc5804>`_,
   so users can manage their scripts using (hopefully) user-friendly ManageSieve
   clients. Many webmails already include a ManageSieve client.
 * Scripts are compiled before they are installed, which guarantees that the
@@ -24,10 +24,9 @@ filesystem:
 Configuration and Use
 =====================
 
-* :ref:`Download and Installation
-  <sieve_installation>`
+* :ref:`Download and Installation <sieve_installation>`
 * `Configuration
-  <https://wiki.dovecot.org/Pigeonhole/ManageSieve/Configuration>`__
+  <https://wiki.dovecot.org/Pigeonhole/ManageSieve/Configuration>`_
 * `Troubleshooting
-  <https://wiki.dovecot.org/Pigeonhole/ManageSieve/Troubleshooting>`__
-* `Client Issues <https://wiki.dovecot.org/Pigeonhole/ManageSieve/Clients>`__
+  <https://wiki.dovecot.org/Pigeonhole/ManageSieve/Troubleshooting>`_
+* `Client Issues <https://wiki.dovecot.org/Pigeonhole/ManageSieve/Clients>`_

--- a/source/admin_manual/system_users_used_by_dovecot.rst
+++ b/source/admin_manual/system_users_used_by_dovecot.rst
@@ -98,8 +98,8 @@ anything special with the groups, so if you're not sure how you should create
 them, you might as well place all the users into a single group or create a
 separate group for each user.
 
-If you use multiple UIDs and you wish to create `shared mailboxes
-<https://wiki.dovecot.org/SharedMailboxes>`_, setting up the groups properly
+If you use multiple UIDs and you wish to create :ref:`shared_mailboxes`,
+setting up the groups properly
 may make your configuration more secure. For example if you have two teams and
 their mailboxes are shared only to their team members, you could create a group
 for each team and set the shared mailbox's group to the team's group and

--- a/source/configuration_manual/authentication/auth_penalty.rst
+++ b/source/configuration_manual/authentication/auth_penalty.rst
@@ -51,4 +51,4 @@ Authentication penalty tracking can be disabled completely with:
      }
    }
 
-Also you can have similar functionality with `fail2ban <http://wiki2.dovecot.org/HowTo/Fail2Ban>`_.
+Also you can have similar functionality with `fail2ban <http://wiki.dovecot.org/HowTo/Fail2Ban>`_.

--- a/source/configuration_manual/authentication/nss.rst
+++ b/source/configuration_manual/authentication/nss.rst
@@ -9,7 +9,7 @@
 .. NOTE:: This userdb is probably useless with Dovecot v2.0.12+, since it uses
           ``getpwnam_r()``, which supports error reporting.
 
-Usually `NSS <https://en.wikipedia.org/wiki/Name_Service_Switch>`__ is used
+Usually `NSS <https://en.wikipedia.org/wiki/Name_Service_Switch>`_ is used
 with :ref:`authentication-passwd` userdb, but it has one problem:
 
    * It can't distinguish between temporary and permanent errors.

--- a/source/configuration_manual/authentication/oauth2.rst
+++ b/source/configuration_manual/authentication/oauth2.rst
@@ -225,7 +225,7 @@ OpenID.Discovery
 
 .. versionadded:: v2.3.16
 
-Support for `RFC 7628 <https://datatracker.ietf.org/doc/html/rfc7628#section-3.2.2>`__  OpenID Discovery (OIDC) can be achieved with
+Support for `RFC 7628 <https://datatracker.ietf.org/doc/html/rfc7628#section-3.2.2>`_  OpenID Discovery (OIDC) can be achieved with
 ``openid_configuration_url`` setting. Setting this causes Dovecot to report OIDC configuration URL as ``openid-configuration`` element in error JSON.
 
 Full config file

--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -19,8 +19,7 @@ Global variables that work everywhere are:
 +------------+-----------------------------------------------------------------------------+
 | Long name  |  Description                                                                |
 +============+=============================================================================+
-| %%         | '%' character. See                                                          |
-|            | `SharedMailboxes/Shared <https://wiki.dovecot.org/SharedMailboxes/Shared>`_ |
+| %%         | '%' character. See :ref:`user_shared_mailboxes`                             |
 |            | for further information about %% variables                                  |
 +------------+-----------------------------------------------------------------------------+
 | env:<name> | Environment variable <name>                                                 |

--- a/source/configuration_manual/fts/solr.rst
+++ b/source/configuration_manual/fts/solr.rst
@@ -3,7 +3,7 @@
 Solr FTS Engine
 ===============
 
-`Solr <https://lucene.apache.org/solr/>`__ is a Lucene indexing server.
+`Solr <https://lucene.apache.org/solr/>`_ is a Lucene indexing server.
 Dovecot communicates to it using HTTP/XML queries.
 
 The steps described in this page are tested for Solr 7.7.0. For
@@ -31,7 +31,7 @@ First, the Solr server needs to be installed. Most operating systems
 will have packages for this. The latest version can be downloaded and
 installed from official website, and here are instructions to install
 7.7.0 based on the howto `How to Install Apache Solr 7.5 on Debian
-9/8 <https://tecadmin.net/install-apache-solr-on-debian/>`__:
+9/8 <https://tecadmin.net/install-apache-solr-on-debian/>`_:
 
 ::
 
@@ -93,9 +93,9 @@ Install schema.xml and solrconfig.xml
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Copy
-`doc/solr-config-7.7.0.xml <https://raw.githubusercontent.com/dovecot/core/master/doc/solr-config-7.7.0.xml>`__
+`doc/solr-config-7.7.0.xml <https://raw.githubusercontent.com/dovecot/core/master/doc/solr-config-7.7.0.xml>`_
 and
-`doc/solr-schema-7.7.0.xml <https://raw.githubusercontent.com/dovecot/core/master/doc/solr-schema-7.7.0.xml>`__
+`doc/solr-schema-7.7.0.xml <https://raw.githubusercontent.com/dovecot/core/master/doc/solr-schema-7.7.0.xml>`_
 (Since Dovecot 2.3.6+) to ``/var/solr/data/dovecot/conf/`` as
 ``solrconfig.xml`` and ``schema.xml``. The ``managed-schema`` file is
 generated based on ``schema.xml``.
@@ -278,7 +278,7 @@ it are:
       ``user_query = SELECT concat('url=https://', solr_host, ':8983/solr/dovecot/') AS fts_solr, ...``
 
 You can also use
-`SolrCloud <https://lucene.apache.org/solr/guide/7_6/solrcloud.html>`__,
+`SolrCloud <https://lucene.apache.org/solr/guide/7_6/solrcloud.html>`_,
 the clustered version of Solr, that allows you to scale up, and adds
 failover / high availability to your FTS system. Dovecot-solr works fine
 with a SolrCloud cluster as long as the solr schema is the right one.
@@ -290,7 +290,7 @@ External sites with tutorials on using Solr under Dovecot
 
 -  `Installing Apache Solr with Dovecot for fulltext search results
    (ATmail support
-   guide) <https://help.atmail.com/hc/en-us/articles/201566404-Installing-Apache-Solr-with-Dovecot-for-fulltext-search-results>`__
+   guide) <https://help.atmail.com/hc/en-us/articles/201566404-Installing-Apache-Solr-with-Dovecot-for-fulltext-search-results>`_
 
 -  FreeBSD: <https://mor-pah.net/2016/08/15/dovecot-2-2-with-solr-6-or-5/>
 

--- a/source/configuration_manual/howto/antispam_with_sieve.rst
+++ b/source/configuration_manual/howto/antispam_with_sieve.rst
@@ -34,7 +34,7 @@ Caveats and possible pitfalls
    setup, you should instead configure Spamassassin to use
    MySQL/PostgreSQL as a backend, unless you want a headache with file
    permissions and lock files. You can find instructions
-   `here <http://www.iredmail.org/docs/store.spamassassin.bayes.in.sql.html>`__.
+   `here <http://www.iredmail.org/docs/store.spamassassin.bayes.in.sql.html>`_.
    In this case, the ``-u`` parameter passed to ``sa-learn`` (and the
    relevant sieve variables) is obsolete and can be safely removed.
 
@@ -43,13 +43,11 @@ Caveats and possible pitfalls
 
 Changes:
 
--  2017/11/20 - Possibility of using spamc with
-   `SpamAssassin <https://wiki2.dovecot.org/SpamAssassin#>`__
-   to mitigate multi-message delays
+-  2017/11/20 - Possibility of using spamc with SpamAssassin to mitigate
+   multi-message delays
 
 -  2017/05/05 - Recommendation about Virtual Users and using an SQL
-   Backend. Added brief info about
-   `RoundCube <https://wiki2.dovecot.org/RoundCube#>`__.
+   Backend. Added brief info about RoundCube.
 
 -  2017/04/01 - Pass imap user to scripts.
 
@@ -220,10 +218,10 @@ For rspamd
 
 By default, rspamd does global learning. If you want per-user
 classification, or something more complex, see
-` <https://rspamd.com/doc/configuration/statistic.html>`__
+https://rspamd.com/doc/configuration/statistic.html
 
 Alternative scripts can be found from
-` <https://github.com/darix/dovecot-sieve-antispam-rspamd/>`__
+https://github.com/darix/dovecot-sieve-antispam-rspamd/
 
 sa-learn-spam.sh
 
@@ -266,8 +264,8 @@ variables are supported in this.
 RoundCube
 ---------
 
-Recent versions of `RoundCube <https://roundcube.net/>`__ include a
+Recent versions of `RoundCube <https://roundcube.net/>`_ include a
 `markasjunk2
-plugin <https://plugins.roundcube.net/packages/johndoh/markasjunk2>`__
+plugin <https://plugins.roundcube.net/packages/johndoh/markasjunk2>`_
 for allowing users to mark Spam/Ham in a convenient way. Please make
 sure the Junk/Spam folder matches your configuration.

--- a/source/configuration_manual/howto/postfix_dovecot_lmtp.rst
+++ b/source/configuration_manual/howto/postfix_dovecot_lmtp.rst
@@ -78,7 +78,7 @@ really nice because Postfix doesn't need to query an external datasource
 (MySQL, LDAP...). Postfix maintain a local database with existing/non
 existing addresses (you can configure how long positive/negative results
 should be cached). `Postfix
-reject_unverified_recipient <http://www.postfix.org/ADDRESS_VERIFICATION_README.html>`__
+reject_unverified_recipient <http://www.postfix.org/ADDRESS_VERIFICATION_README.html>`_
 
 To use LMTP and dynamic address verification you must first get Dovecot
 working. Then you can configure Postfix to use LMTP and set

--- a/source/configuration_manual/howto/simple_virtual_install.rst
+++ b/source/configuration_manual/howto/simple_virtual_install.rst
@@ -18,7 +18,7 @@ System configuration
 
 -  Create ``/home/vmail`` directory owned by vmail:vmail. The mails for all users are stored under this directory.
 
--  Create ``/var/log/dovecot.log`` and ``/var/log/dovecot-info.log`` files owned by vmail:vmail, so that `dovecot-lda <https://wiki2.dovecot.org/LDA>`__ can write to them.
+-  Create ``/var/log/dovecot.log`` and ``/var/log/dovecot-info.log`` files owned by vmail:vmail, so that :ref:`lda` can write to them.
 
 dovecot.conf
 ============
@@ -116,10 +116,11 @@ SMTP server configuration
 Delivering mails
 ----------------
 
-You can configure the SMTP server to deliver mails internally, or you can use `dovecot-lda <https://wiki2.dovecot.org/LDA>`__.
-Using dovecot-lda gives you better performance because it updates Dovecot's index files while saving the mails.
-See`LDA <https://wiki2.dovecot.org/LDA>`__ for how to configure this.
-Alternatively you can also use :ref:`LMTP <lmtp_server>`.
+You can configure the SMTP server to deliver mails internally, or you can use
+:ref:`lda`. Using dovecot-lda gives you better performance because it updates
+Dovecot's index files while saving the mails. See :ref:`lda` for configuration
+information. Alternatively you can also use :ref:`LMTP <lmtp_server>`.
+
 In config you should have:
 
 ::

--- a/source/configuration_manual/mail_location/Maildir/index.rst
+++ b/source/configuration_manual/mail_location/Maildir/index.rst
@@ -60,15 +60,14 @@ cache and download the messages all over again. If you do this for all the
 users, you could cause huge disk I/O bursts to your server.
 
 Dovecot cannot currently handle not being able to write the control files, so
-it will cause problems with `filesystem quota`_. To avoid problems with this,
+it will cause problems with :ref:`filesystem quota <quota_backend_fs>`. To
+avoid problems with this,
 you should place control files into a partition where quota isn't checked. You
 can specify this by adding ``:CONTROL=<path>`` to ``mail_location``:
 
 .. code-block:: none
 
   mail_location = maildir:~/Maildir:CONTROL=/var/no-quota/%u
-
-.. _`filesystem quota`: https://wiki.dovecot.org/Quota/FS
 
 Index Files
 ^^^^^^^^^^^

--- a/source/configuration_manual/mail_location/imapc/index.rst
+++ b/source/configuration_manual/mail_location/imapc/index.rst
@@ -249,7 +249,7 @@ The port on the remote IMAP host to connect to.
 
 Log all IMAP traffic input/output to this directory.
 
-See: https://wiki.dovecot.org/Debugging/Rawlog
+See: :ref:`debugging_rawlog`.
 
 
 .. _setting-imapc_sasl_mechanisms:

--- a/source/configuration_manual/mail_location/index.rst
+++ b/source/configuration_manual/mail_location/index.rst
@@ -180,7 +180,7 @@ Example:
 
 Index files
 ^^^^^^^^^^^
-Index files are by default stored under the same directory as mails. With maildir they are stored in the actual maildirs, with mbox they are stored under ``.imap/`` directory. You may want to change the index file location if you're using `NFS <https://wiki.dovecot.org/NFS>`_ or if you're setting up `shared mailboxes <https://wiki.dovecot.org/SharedMailboxes>`_.
+Index files are by default stored under the same directory as mails. With maildir they are stored in the actual maildirs, with mbox they are stored under ``.imap/`` directory. You may want to change the index file location if you're using :ref:`nfs` or if you're setting up :ref:`shared_mailboxes`.
 
 You can change the index file location by adding ``:INDEX=<path>`` to mail_location. For example:
 

--- a/source/configuration_manual/namespace/index.rst
+++ b/source/configuration_manual/namespace/index.rst
@@ -220,10 +220,8 @@ Namespace types
 There are 3 types of namespaces:
 
 * private: Typically contains only user's own private mailboxes.
-* shared: Contains other users' `shared mailboxes
-  <https://wiki.dovecot.org/SharedMailboxes/Shared>`_
-* public: Contains `public mailboxes
-  <https://wiki.dovecot.org/SharedMailboxes/Public>`_
+* shared: Contains other users' :ref:`shared mailboxes <user_shared_mailboxes>`.
+* public: Contains :ref:`public mailboxes <public_shared_mailboxes>`.
 
 .. _hierarchy-separators:
 
@@ -341,8 +339,7 @@ currently no way to simply `add` a namespace.
 
 Dovecot Support for Shared Mailboxes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Dovecot can support mailbox sharing in several different ways: `Dovecot Shared
-Mailboxes <https://wiki.dovecot.org/SharedMailboxes>`_
+See :ref:`mailbox sharing <shared_mailboxes>`.
 
 Examples:
 ^^^^^^^^^^

--- a/source/configuration_manual/nfs.rst
+++ b/source/configuration_manual/nfs.rst
@@ -70,8 +70,9 @@ Clock synchronization
 =====================
 
 Run ntpd in the NFS server and all the NFS clients to make sure their
-clocks are synchronized. They should always be less than 1 second apart
-from each other.
+clocks are synchronized. If the clocks are more than one second apart
+from each others and multiple computers access the same mailbox
+simultaneously, you may get errors.
 
 Clustering without director
 ===========================
@@ -109,4 +110,3 @@ configuration.
           protocol lda {
             mail_location = maildir:~/Maildir:INDEX=MEMORY
           }
-

--- a/source/configuration_manual/protocols/lda.rst
+++ b/source/configuration_manual/protocols/lda.rst
@@ -5,43 +5,34 @@ Dovecot LDA
 ===========
 
 The Dovecot LDA is a `local delivery
-agent <https://wiki2.dovecot.org/MDA#>`__, which takes mail from an
-`MTA <https://wiki2.dovecot.org/MTA#>`__ and delivers it to a user's
-mailbox, while keeping Dovecot index files up to date. Nowadays you
-should probably use the `LMTP
-server <https://wiki2.dovecot.org/LMTP#>`__ instead, because it's
-somewhat easier to configure (especially related to permissions) and
-gives better performance.
+agent <https://wiki.dovecot.org/MDA>`_, which takes mail from an :ref:`mta`
+and delivers it to a user's mailbox, while keeping Dovecot index files up to
+date. Nowadays you should probably use the `LMTP server <lmtp_server>`
+instead, because it's somewhat easier to configure (especially related to
+permissions) and gives better performance.
 
 This page describes the common settings required to make LDA work. You
 should read it first, and then the MTA specific pages:
 
--  `LDA/Postfix <https://wiki2.dovecot.org/LDA/Postfix#>`__
-
--  `LDA/Exim <https://wiki2.dovecot.org/LDA/Exim#>`__
-
--  `LDA/Sendmail <https://wiki2.dovecot.org/LDA/Sendmail#>`__
-
--  `LDA/Qmail <https://wiki2.dovecot.org/LDA/Qmail#>`__
-
--  `LDA/ZMailer <https://wiki2.dovecot.org/LDA/ZMailer#>`__
+-  `LDA/Postfix <https://wiki.dovecot.org/LDA/Postfix>`_
+-  `LDA/Exim <https://wiki.dovecot.org/LDA/Exim>`_
+-  `LDA/Sendmail <https://wiki.dovecot.org/LDA/Sendmail>`_
+-  `LDA/Qmail <https://wiki.dovecot.org/LDA/Qmail>`_
+-  `LDA/ZMailer <https://wiki.dovecot.org/LDA/ZMailer>`_
 
 Main features of Dovecot LDA
 ----------------------------
 
 -  `Mailbox indexing during mail
-   delivery <https://wiki2.dovecot.org/LDA/Indexing#>`__, providing
+   delivery <https://wiki.dovecot.org/LDA/Indexing>`_, providing
    faster mailbox access later
 
 -  :ref:`Quota enforcing by a plugin <quota_plugin>`
 
--  :ref:`Sieve language support by a
-   plugin <sieve>`
+-  :ref:`Sieve language support by a plugin <sieve>`
 
    -  Mail filtering
-
    -  Mail forwarding
-
    -  Vacation auto-reply
 
 Common configuration
@@ -164,7 +155,7 @@ You can use LDA with a few selected system users (ie. user is found from
 
 This should work with any MTA which supports per-user ``.forward``
 files. For qmail's per-user setup, see
-`LDA/Qmail <https://wiki2.dovecot.org/LDA/Qmail#>`__.
+`LDA/Qmail <https://wiki.dovecot.org/LDA/Qmail>`_.
 
 This method doesn't require the authentication socket explained below
 since it's executed as the user itself.
@@ -308,7 +299,7 @@ Logging
    failure.
 
 -  If you have trouble finding where Dovecot logs by default, see
-   `Logging <https://wiki2.dovecot.org/Logging#>`__.
+   :ref:`dovecot_logging`.
 
 -  Note that Postfix's ``mailbox_size_limit`` setting applies to all
    files that are written to. So if you have a limit of 50 MB,
@@ -353,12 +344,9 @@ For using syslog with dovecot-lda, set the paths empty:
 Plugins
 -------
 
--  Most of the `Dovecot
-   plugins <https://wiki2.dovecot.org/Plugins#>`__ work with
-   dovecot-lda.
+-  Most of the :ref:`Dovecot plugins <setting-plugins>` work with dovecot-lda.
 
--  Virtual quota can be enforced using :ref:`Quota
-   plugin <quota_plugin>`.
+-  Virtual quota can be enforced using :ref:`Quota plugin <quota_plugin>`.
 
 -  Sieve language support can be added with the :ref:`Pigeonhole Sieve
    plugin <sieve>`.

--- a/source/configuration_manual/push_notification.rst
+++ b/source/configuration_manual/push_notification.rst
@@ -108,8 +108,9 @@ OX (Open-Xchange) driver [``ox``]
 The OX backend supports sending notifications on MessageNew events (i.e. mail
 deliveries, not IMAP APPENDs).
 
-This driver was designed for use with `OX App Suite <https://documentation.open-xchange.com/7.10.5/middleware/mail/dovecot/dovecot_push.html>`_, but can be
-used by any push endpoint that implements the OX Push Notification API.
+This driver was designed for use with
+`OX App Suite Push Notification API <https://documentation.open-xchange.com/7.10.5/middleware/mail/dovecot/dovecot_push.html>`_, but can be
+used by any push endpoint that implements this API, not just OX App Suite.
 
 Configuration options:
 
@@ -147,8 +148,8 @@ Metadata
 --------
 
 The push notifications are enabled separately for each user using METADATA.
-Normally OX App Suite does this internally, but for testing purposes you can
-do this yourself:
+Normally `OX App Suite <https://www.open-xchange.com/products/ox-app-suite/>`_
+does this internally, but for e.g. testing purposes you can do this yourself:
 
 .. code-block:: none
 

--- a/source/configuration_manual/quick_configuration.rst
+++ b/source/configuration_manual/quick_configuration.rst
@@ -177,7 +177,7 @@ NFS
 ---
 
 If you're using NFS or some other remote filesystem that's shared between
-multiple computers, you should read `NFS <https://wiki.dovecot.org/NFS>`_.
+multiple computers, you should read :ref:`nfs`.
 
 Running
 -------

--- a/source/configuration_manual/quota/quota_imapc.rst
+++ b/source/configuration_manual/quota/quota_imapc.rst
@@ -3,6 +3,5 @@
 ====================
 Quota Backend: imapc
 ====================
-See `imapc`_.
 
-.. _`imapc`: https://wiki.dovecot.org/MailboxFormat/imapc
+See :ref:`imapc_mbox_format`.

--- a/source/configuration_manual/service_configuration.rst
+++ b/source/configuration_manual/service_configuration.rst
@@ -122,6 +122,8 @@ mode
 ^^^^^
 Mode of the file. Defaults to 0700. Note that 0700 is an octal value, while 700 is a different decimal value. Setting mode to ``0`` disables the listener.
 
+.. _service_configuration_inet_listeners:
+
 inet_listeners
 ^^^^^^^^^^^^^^
 

--- a/source/configuration_manual/shared_mailboxes/cluster_setup.rst
+++ b/source/configuration_manual/shared_mailboxes/cluster_setup.rst
@@ -123,8 +123,7 @@ possibilities for it are:
 -  sql: Shared SQL server
 
 -  Any other :ref:`shared dictionary <dict>` can be used like described at
-   :ref:`user_shared_mailboxes_shared_mailbox_listing`
-
+   :ref:`user_shared_mailboxes_shared_mailbox_listing`.
 
 Please also see :ref:`mailbox_sharing_in_cluster_simple_example`.
 

--- a/source/configuration_manual/shared_mailboxes/shared_mailboxes.rst
+++ b/source/configuration_manual/shared_mailboxes/shared_mailboxes.rst
@@ -176,8 +176,7 @@ Using SQL dictionary
      acl = pgsql:/etc/dovecot/dovecot-dict-sql.conf.ext
    }
 
-See `Dict <https://wiki.dovecot.org/SharedMailboxes/Shared/Dict#>`__ for
-more information, especially about permission issues.
+See :ref:`dict` for more information, especially about permission issues.
 
 Database tables:
 
@@ -235,7 +234,7 @@ or it can be done using IMAP SETACL command. It is
 the only way to update the shared mailbox list dictionary.
 
 Below is a quick introduction to IMAP ACL commands. See `RFC
-4314 <http://www.ietf.org/rfc/rfc4314.txt>`__ for more details.
+4314 <http://www.ietf.org/rfc/rfc4314.txt>`_ for more details.
 
 -  ``MYRIGHTS <mailbox>``: Returns the user's current rights to the mailbox.
 
@@ -254,8 +253,7 @@ Below is a quick introduction to IMAP ACL commands. See `RFC
         -  ``$group``: Matches all users belonging to the group ($ is not part of
            the group name).
 
-        -  ``$!group``: See group-override in
-           `ACL <https://wiki.dovecot.org/SharedMailboxes/Shared/ACL#>`__
+        -  ``$!group``: See ``group-override`` in :ref:`acl`
            (Dovecot-specific feature).
 
         -  ``user``: Matches the given user.

--- a/source/configuration_manual/sieve/configuration.rst
+++ b/source/configuration_manual/sieve/configuration.rst
@@ -178,7 +178,7 @@ applicable):
    to specify differences relative to the default. For example
    :ref:`plugin-sieve-setting-sieve_extensions` = +imapflags will enable the `deprecated
    imapflags
-   extension <http://tools.ietf.org/html/draft-melnikov-sieve-imapflags-03>`__
+   extension <http://tools.ietf.org/html/draft-melnikov-sieve-imapflags-03>`_
    in addition to all extensions enabled by default.
 
 :ref:`plugin-sieve-setting-sieve_global_extensions` = (v0.3+)
@@ -227,7 +227,7 @@ applicable):
 :ref:`setting-recipient_delimiter` = +
    The separator that is expected between the :user and :detail address
    parts introduced by the `subaddress
-   extension <http://tools.ietf.org/html/rfc5233/>`__. This may also be
+   extension <http://tools.ietf.org/html/rfc5233/>`_. This may also be
    a sequence of characters (e.g. '--'). The current implementation
    looks for the separator from the left of the localpart and uses the
    first one encountered. The :user part is left of the separator and
@@ -649,21 +649,20 @@ config file (as explained :ref:`above <pigeonhole_configuration_basic_configurat
 However, there are a few important differences in the supported Sieve language features:
 
 -  The **imapflags** extension is now called **imap4flags**. The
-   CMUSieve implementation is based on an `old draft
-   specification <http://tools.ietf.org/html/draft-melnikov-sieve-imapflags-03>`__
-   that is not completely compatible with the `new
-   version <http://tools.ietf.org/html/rfc5232/>`__. Particularly, the
+   CMUSieve implementation is based on an `old imapflags draft
+   specification <http://tools.ietf.org/html/draft-melnikov-sieve-imapflags-03>`_
+   that is not completely compatible with `RFC 5232
+   <http://tools.ietf.org/html/rfc5232/>`_. Particularly, the
    **mark** and **unmark** commands were removed from the new
    specification. For backwards compatibility, support for the old
    imapflags extension can be enabled using the :ref:`plugin-sieve-setting-sieve_extensions`
-   setting (as explained `above <#configuration>`__). This is disabled
-   by default.
+   setting. This is disabled by default.
 
 -  The **notify** extension is now called **enotify**. The CMUSieve
-   implementation is based on an `old draft
-   specification <http://tools.ietf.org/html/draft-martin-sieve-notify-01>`__
-   that is not completely compatible with the `new
-   version <http://tools.ietf.org/html/rfc5435/>`__. Particularly, the
+   implementation is based on an `old notify draft
+   specification <http://tools.ietf.org/html/draft-martin-sieve-notify-01>`_
+   that is not completely compatible with `RFC5425
+   <http://tools.ietf.org/html/rfc5435/>`_. Particularly, the
    **denotify** command and **$text$** substitutions were removed from
    the new specification. For backwards compatibility, support for the
    old imapflags extension can be enabled using the :ref:`plugin-sieve-setting-sieve_extensions`
@@ -688,7 +687,7 @@ From Dovecot Sieve v0.1.x (Dovecot v1.2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The :ref:`plugin-sieve-setting-sieve_subaddress_sep` setting for the `Sieve subaddress
-   extension <http://tools.ietf.org/html/rfc5233/>`__ is now known as
+   extension <http://tools.ietf.org/html/rfc5233/>`_ is now known as
    :ref:`setting-recipient_delimiter`. Although :ref:`plugin-sieve-setting-sieve_subaddress_sep` is still
    recognized for backwards compatibility, it is recommended to update
    the setting to the new name, since the :ref:`LMTP <lmtp_server>`

--- a/source/configuration_manual/sieve/dict.rst
+++ b/source/configuration_manual/sieve/dict.rst
@@ -6,6 +6,7 @@ Pigeonhole Sieve: Dict Lookup for Sieve Scripts
 
 Sieve scripts can be obtained from a number of different :ref:`types of
 locations <pigeonhole_configuration_script_locations>`.
+
 This page shows how to retrieve them from a :ref:`Dovecot dictionary <dict>`
 (abbreviated as 'dict'), which can have either a file or database backend.
 

--- a/source/configuration_manual/sieve/examples.rst
+++ b/source/configuration_manual/sieve/examples.rst
@@ -203,7 +203,7 @@ The virustest extension can be used in a similar manner:
 Plus Addressed mail filtering
 -----------------------------
 
-Using the `subaddress <http://tools.ietf.org/html/rfc5233/>`__
+Using the `subaddress <http://tools.ietf.org/html/rfc5233/>`_
 extension, it is possible to match against the 'detail' part of an
 e-mail address, e.g. a '``+tag``' suffix to the local part of the
 address. This is for example useful when you don't want just any +tag to
@@ -219,7 +219,7 @@ user+spam@example.com into user's Spam folder.
    }
 
 The following more advanced example uses the
-`subaddress <http://tools.ietf.org/html/rfc5233/>`__ extension to handle
+`subaddress <http://tools.ietf.org/html/rfc5233/>`_ extension to handle
 recipient addresses structured as ``sales+<name>@company.com`` in a
 special way. The ``<name>`` part is extracted from the address using
 :ref:`variables <pigeonhole_extension_variables>` extension,
@@ -367,12 +367,12 @@ tree as follows:
 
 For example, in March 2013 this puts messages from the Dovecot mailing
 list in a folder called ``INBOX.Lists.2013.03.dovecot``. It combines the
-`date <http://tools.ietf.org/html/rfc5260#section-4>`__ and
+`date <http://tools.ietf.org/html/rfc5260#section-4>`_ and
 :ref:`variables <pigeonhole_extension_variables>` extensions to
 extract the required date strings. Using the ``:create`` argument for
 the ``fileinto`` command, the indicated folder is created automatically
 if it doesn't exist. The ``:create`` argument is provided by the
-`mailbox <http://tools.ietf.org/html/rfc5490#section-3>`__ extension.
+`mailbox <http://tools.ietf.org/html/rfc5490#section-3>`_ extension.
 
 Emulating :ref:`lmtp_save_to_detail_mailbox=yes <setting-lmtp_save_to_detail_mailbox>`
 --------------------------------------------------------------------------------------
@@ -396,7 +396,7 @@ Translation from Procmail
 There exists a script which attempts to translate simple Procmail rules
 into Sieve rules:
 http://www.earth.ox.ac.uk/~steve/sieve/procmail2sieve.pl
-(`dovecot.org mirror <http://dovecot.org/tools/procmail2sieve.pl>`__)
+(`dovecot.org mirror <http://dovecot.org/tools/procmail2sieve.pl>`_)
 
 Here's the original post announcing it:
 http://dovecot.org/list/dovecot/2007-March/020895.html.

--- a/source/configuration_manual/sieve/extensions/duplicate.rst
+++ b/source/configuration_manual/sieve/extensions/duplicate.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Duplicate Extension
 =====================================
 
 The **duplicate** extension `RFC
-7353 <http://tools.ietf.org/html/rfc7352>`__ adds a new test command
+7353 <http://tools.ietf.org/html/rfc7352>`_ adds a new test command
 called ``duplicate`` to the Sieve language. This test adds the ability
 to detect duplications. The main application for this new test is
 handling duplicate deliveries commonly caused by mailing list
@@ -17,9 +17,9 @@ or other parts of the message.
 
 Previously, this extension was Dovecot-specific and available under the
 name ``vnd.dovecot.duplicate``. Specification for old version available
-`here <http://hg.rename-it.nl/dovecot-2.1-pigeonhole/raw-file/tip/doc/rfc/spec-bosch-sieve-duplicate.txt>`__.
+`here <http://hg.rename-it.nl/dovecot-2.1-pigeonhole/raw-file/tip/doc/rfc/spec-bosch-sieve-duplicate.txt>`_.
 That implementation differs significantly from what is now published as
-`RFC 7353 <http://tools.ietf.org/html/rfc7352>`__, but the original
+`RFC 7353 <http://tools.ietf.org/html/rfc7352>`_, but the original
 extension is still supported for backwards compatibility.
 
 Configuration

--- a/source/configuration_manual/sieve/extensions/editheader.rst
+++ b/source/configuration_manual/sieve/extensions/editheader.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Editheader Extension
 ======================================
 
 The **editheader** extension
-(`RFC5293 <http://tools.ietf.org/html/rfc5293/>`__) enables Sieve
+(`RFC5293 <http://tools.ietf.org/html/rfc5293/>`_) enables Sieve
 scripts to delete and add message header fields, thereby allowing
 interaction with other components that consume or produce header fields.
 

--- a/source/configuration_manual/sieve/extensions/enotify.rst
+++ b/source/configuration_manual/sieve/extensions/enotify.rst
@@ -6,7 +6,7 @@ Pigeonhole Sieve: Extension for Notifications
 
 
 The Sieve **enotify** extension
-(`RFC5435 <http://tools.ietf.org/html/rfc5435/>`__) adds the notify action to the Sieve language.
+(`RFC5435 <http://tools.ietf.org/html/rfc5435/>`_) adds the notify action to the Sieve language.
 
 Configuration
 =============

--- a/source/configuration_manual/sieve/extensions/include.rst
+++ b/source/configuration_manual/sieve/extensions/include.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Include Extension
 ===================================
 
 The Sieve **include** extension (`RFC
-6609 <http://tools.ietf.org/html/rfc6609>`__) permits users to include
+6609 <http://tools.ietf.org/html/rfc6609>`_) permits users to include
 one Sieve script into another. This can make managing large scripts or
 multiple sets of scripts much easier, and allows a site and its users to
 build up libraries of scripts. Users are able to include their own

--- a/source/configuration_manual/sieve/extensions/spamtest_virustest.rst
+++ b/source/configuration_manual/sieve/extensions/spamtest_virustest.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Spamtest and Virustest Extensions
 ===================================================
 
 Using the **spamtest** and **virustest** extensions (`RFC
-5235 <http://tools.ietf.org/html/rfc5235/>`__), the Sieve language
+5235 <http://tools.ietf.org/html/rfc5235/>`_), the Sieve language
 provides a uniform and standardized command interface for evaluating
 spam and virus tests performed on the message. Users no longer need to
 know what headers need to be checked and how the scanner's verdict is

--- a/source/configuration_manual/sieve/extensions/vacation.rst
+++ b/source/configuration_manual/sieve/extensions/vacation.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Vacation Extension
 ====================================
 
 The Sieve vacation extension
-(`RFC5230 <http://tools.ietf.org/html/rfc5230/>`__) defines a mechanism
+(`RFC5230 <http://tools.ietf.org/html/rfc5230/>`_) defines a mechanism
 to generate automatic replies to incoming email messages. It takes
 various precautions to make sure replies are only sent when appropriate.
 Script authors can specify how often replies can be sent to a particular
@@ -13,7 +13,7 @@ contact. In the original vacation extension, this interval is specified
 in days with a minimum of one day. When more granularity is necessary
 and particularly when replies must be sent more frequently than one day,
 the vacation-seconds extension
-(`RFC6131 <http://tools.ietf.org/html/rfc6131/>`__) can be used. This
+(`RFC6131 <http://tools.ietf.org/html/rfc6131/>`_) can be used. This
 allows specifying the minimum reply interval in seconds with a minimum
 of zero (a reply is then always sent), depending on administrator
 configuration.

--- a/source/configuration_manual/sieve/extensions/variables.rst
+++ b/source/configuration_manual/sieve/extensions/variables.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Variables Extension
 =====================================
 
 The Sieve **variables** extension
-(`RFC5229 <http://tools.ietf.org/html/rfc5229/>`__) adds the concept of
+(`RFC5229 <http://tools.ietf.org/html/rfc5229/>`_) adds the concept of
 variables to the Sieve language.
 
 Configuration

--- a/source/configuration_manual/sieve/installation.rst
+++ b/source/configuration_manual/sieve/installation.rst
@@ -8,7 +8,7 @@ Getting the sources
 -------------------
 
 You can download the latest released sources from the `Pigeonhole
-download page <http://pigeonhole.dovecot.org/download.html>`__.
+download page <http://pigeonhole.dovecot.org/download.html>`_.
 
 Alternatively, you can get the sources, including the most recent
 unreleased changes, from the the `GitHub repository <https://github.com/dovecot/pigeonhole>`_ :

--- a/source/configuration_manual/sieve/plugins/extdata.rst
+++ b/source/configuration_manual/sieve/plugins/extdata.rst
@@ -153,5 +153,5 @@ Finally configure extdata to use the proxy:
    sieve_extdata_dict_uri = proxy::sieve
 
 Read the (preliminary)
-`specification <https://github.com/stephanbosch/sieve-extdata-plugin/blob/core-0.5/doc/rfc/spec-bosch-sieve-external-data.txt>`__
+`specification <https://github.com/stephanbosch/sieve-extdata-plugin/blob/core-0.5/doc/rfc/spec-bosch-sieve-external-data.txt>`_
 for more information.

--- a/source/configuration_manual/sieve/plugins/extprograms.rst
+++ b/source/configuration_manual/sieve/plugins/extprograms.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Extprograms Plugin
 ====================================
 
 The "sieve_extprograms" plugin provides an extension to the `Sieve
-filtering language <http://www.sieve.info>`__ adding new action commands
+filtering language <http://www.sieve.info>`_ adding new action commands
 for invoking a predefined set of external programs. Messages can be
 piped to or filtered through those programs and string data can be input
 to and retrieved from those programs. To mitigate the security concerns,
@@ -15,7 +15,7 @@ programs are restricted through administrator configuration.
 This plugin is only available for Pigeonhole
 v0.3 and higher (available for Dovecot v2.1). For Pigeonhole 
 v0.4 this plugin is part of the release. This an evolution of the `Pipe
-plugin <https://wiki2.dovecot.org/Pigeonhole/Sieve/Plugins/Pipe#>`__
+plugin <https://wiki.dovecot.org/Pigeonhole/Sieve/Plugins/Pipe>`_
 for Pigeonhole v0.2 and now provides the ``filter`` and ``execute`` commands
 (and corresponding extensions) in addition to the ``pipe`` command that
 was provided earlier by the Pipe plugin.
@@ -157,7 +157,7 @@ Usage
 -----
 
 Read the specification (`v0.3
-plugin <http://hg.rename-it.nl/pigeonhole-0.3-sieve-extprograms/raw-file/tip/doc/rfc/spec-bosch-sieve-extprograms.txt>`__/`v0.4+ <https://github.com/dovecot/pigeonhole/blob/master/doc/rfc/spec-bosch-sieve-extprograms.txt>`__)
+plugin <http://hg.rename-it.nl/pigeonhole-0.3-sieve-extprograms/raw-file/tip/doc/rfc/spec-bosch-sieve-extprograms.txt>`_/`v0.4+ <https://github.com/dovecot/pigeonhole/blob/master/doc/rfc/spec-bosch-sieve-extprograms.txt>`_)
 for detailed information on how to use the new language extensions.
 
 Full Examples

--- a/source/configuration_manual/sieve/plugins/imapfilter_sieve.rst
+++ b/source/configuration_manual/sieve/plugins/imapfilter_sieve.rst
@@ -4,7 +4,7 @@ Pigeonhole IMAP FILTER=SIEVE Plugin
 
 Normally, Sieve filters can either be applied at initial mail delivery
 or triggered by certain events in the Internet Message Access Protocol
-(``IMAPSIEVE``; `RFC 6785 <http://tools.ietf.org/html/rfc6785>`__). The
+(``IMAPSIEVE``; `RFC 6785 <http://tools.ietf.org/html/rfc6785>`_). The
 user can configure which Sieve scripts to run at these instances, but it
 is not possible to trigger the execution of Sieve scripts manually.
 However, this could be very useful; e.g, to test new Sieve rules and to
@@ -18,7 +18,7 @@ on a set of messages that match the specified IMAP searching criteria.
 
 The latest draft of the specification for this IMAP capability is
 available
-`here <https://github.com/dovecot/pigeonhole/blob/master/doc/rfc/draft-bosch-imap-filter-sieve-00.txt>`__.
+`here <https://github.com/dovecot/pigeonhole/blob/master/doc/rfc/draft-bosch-imap-filter-sieve-00.txt>`_.
 This plugin is experimental and the specification is likely to change.
 Use the specification included in your current release to obtain the
 matching specification for your release.

--- a/source/configuration_manual/sieve/plugins/imapsieve.rst
+++ b/source/configuration_manual/sieve/plugins/imapsieve.rst
@@ -5,10 +5,10 @@ Pigeonhole: IMAPSieve Plugin
 ============================
 
 As defined in the base specification (`RFC
-5228 <http://tools.ietf.org/html/rfc5228>`__), the Sieve language is
+5228 <http://tools.ietf.org/html/rfc5228>`_), the Sieve language is
 used only during delivery. However, in principle, it can be used at any
 point in the processing of an email message. `RFC
-6785 <http://tools.ietf.org/html/rfc6785>`__ defines the use of Sieve
+6785 <http://tools.ietf.org/html/rfc6785>`_ defines the use of Sieve
 filtering in IMAP, operating when messages are created or their
 attributes are changed. This feature extends both Sieve and IMAP.
 Therefore, Pigeonhole provides both an IMAP plugin and a Sieve plugin.
@@ -67,7 +67,7 @@ that is invoked from IMAP. When it is used in the active delivery
 script, it will cause runtime errors. To make a Sieve script suitable
 for both delivery and IMAP, the availability of the extension can be
 tested using the ``ihave`` test (`RFC
-5463 <http://tools.ietf.org/html/rfc5463>`__) as usual.
+5463 <http://tools.ietf.org/html/rfc5463>`_) as usual.
 
 The following settings are recognized the "imap_sieve" plugin:
 
@@ -108,7 +108,7 @@ The following settings are recognized the "imap_sieve" plugin:
    Only execute the administrator Sieve scripts for the mailbox
    configured with ``imapsieve_mailboxXXX_name`` when one of the listed
    ``IMAPSIEVE``
-   `causes <https://tools.ietf.org/html/rfc6785#section-4.3>`__ apply
+   `causes <https://tools.ietf.org/html/rfc6785#section-4.3>`_ apply
    (currently either ``APPEND``, ``COPY``, or ``FLAG``. This has no
    effect on the user script, which is always executed no matter the
    cause.

--- a/source/configuration_manual/sieve/troubleshooting.rst
+++ b/source/configuration_manual/sieve/troubleshooting.rst
@@ -107,8 +107,8 @@ instructions <sieve_configuration_from_cmusieve>` again.
 
 Often the 'author' of such scripts is an older or misconfigured Sieve
 GUI editor. For example, the
-`SieveRules <https://github.com/JohnDoh/Roundcube-Plugin-SieveRules-Managesieve#readme>`__
-plugin for the `RoundCube webmail IMAP client <http://roundcube.net/>`__
+`SieveRules <https://github.com/JohnDoh/Roundcube-Plugin-SieveRules-Managesieve#readme>`_
+plugin for the `RoundCube webmail IMAP client <http://roundcube.net/>`_
 has a configuration option to enable the correct behavior:
 
 ::

--- a/source/developer_manual/design/dcrypt.rst
+++ b/source/developer_manual/design/dcrypt.rst
@@ -14,7 +14,7 @@ ECDH algorithm
 
 ECDH (Elliptic curve Diffie-Hellman) is widely used in lib-dcrypt for
 both key and data storage. This algorithm is also known as
-`ECIES <https://en.wikipedia.org/wiki/ECIES>`__ (Elliptic curve
+`ECIES <https://en.wikipedia.org/wiki/ECIES>`_ (Elliptic curve
 Integrated Encryption Scheme).
 
 When encrypting data, we perform following steps, this is the currently
@@ -66,7 +66,7 @@ Key formats
 -----------
 
 lib-dcrypt can consume keys in `PEM
-format <https://tools.ietf.org/html/rfc1421>`__ (with or without
+format <https://tools.ietf.org/html/rfc1421>`_ (with or without
 password), and in Dovecot's special format intended for dict storage.
 
 Dovecot's format consists from unencrypted and encrypted keys. You can
@@ -125,4 +125,4 @@ File format is described below
    ekh - (eof-maclen) payload data
 
 There is a small script for decrypting these files, see
-`decrypt.rb <https://wiki.dovecot.org/Design/Dcrypt?action=AttachFile&do=get&target=decrypt.rb>`__.
+`decrypt.rb <https://wiki.dovecot.org/Design/Dcrypt?action=AttachFile&do=get&target=decrypt.rb>`_.

--- a/source/developer_manual/design/doveadm_protocol.rst
+++ b/source/developer_manual/design/doveadm_protocol.rst
@@ -101,4 +101,4 @@ sent in one line. So in the above case the protocol output will be:
 Example Clients
 ---------------
 
--  Perl: `Net::Doveadm <https://metacpan.org/pod/Net::Doveadm>`__
+-  Perl: `Net::Doveadm <https://metacpan.org/pod/Net::Doveadm>`_

--- a/source/developer_manual/design/mail_storage.rst
+++ b/source/developer_manual/design/mail_storage.rst
@@ -6,8 +6,7 @@ Mail Storage
 
 ``src/lib-storage/mail-storage.h`` and ``mail-storage-private.h``
 describes mail storage. Mail storage is mainly about being a common
-container for its mailboxes. For example with
-`multi-dbox <https://wiki.dovecot.org/MailboxFormat/dbox#>`__
+container for its mailboxes. For example with :ref:`dbox_mbox_format`,
 each storage has one directory where all the message bodies are written
 to, while the per-mailbox directories only contain index files. With
 other mailbox formats mail storage doesn't do much else than allow

--- a/source/developer_manual/design/mailbox_list.rst
+++ b/source/developer_manual/design/mailbox_list.rst
@@ -40,9 +40,7 @@ Mailbox list is configured by
    be deleted. For example subscriptions file is a control file.
    Defaults to root_dir.
 
--  alt_dir: This is currently
-   `dbox <https://wiki.dovecot.org/MailboxFormat/dbox#>`__-specific
-   setting.
+-  alt_dir: This is currently :ref:`dbox <dbox_mbox_format>`-specific setting.
 
 -  inbox_path: Path to INBOX mailbox. This exists mainly because with
    mbox format INBOX is often in a different location than other

--- a/source/developer_manual/design/mailbox_syncing.rst
+++ b/source/developer_manual/design/mailbox_syncing.rst
@@ -112,8 +112,8 @@ deinitialized, the sequences change.
 Message flag change records don't actually show what the changes were.
 You can find the new flags just by fetching them (``mail_get_flags()``,
 etc.), they're available immediately. You'll need to create a
-`transaction <lib-storage_mailbox_transactions>`__ and a
-`mail <lib-storage_mail>`__ for that. For example:
+`transaction <lib-storage_mailbox_transactions>` and a
+`mail <lib-storage_mail>` for that. For example:
 
 .. code-block:: C
 

--- a/source/developer_manual/design/parameter_forwarding.rst
+++ b/source/developer_manual/design/parameter_forwarding.rst
@@ -63,7 +63,7 @@ Supported parameters
 SMTP/LMTP protocol
 ------------------
 
-See `<http://www.postfix.org/XCLIENT_README.html>`__
+See http://www.postfix.org/XCLIENT_README.html
 
 -  ``ADDR`` - Client IP, IPV6: prefix is needed for IPv6.
 

--- a/source/developer_manual/development_tips/clang_patching.rst
+++ b/source/developer_manual/development_tips/clang_patching.rst
@@ -13,7 +13,7 @@ Source Repos
 ------------
 
 There are github mirrors, but you can clone directly from
-`llvm.org <http://llvm.org>`__
+`llvm.org <http://llvm.org/>`_.
 
 .. code-block:: sh
 

--- a/source/developer_manual/development_tips/debugging_tips.rst
+++ b/source/developer_manual/development_tips/debugging_tips.rst
@@ -71,8 +71,7 @@ Standalone non-root debugging environments
 Dovecot can be instructed to run the imap handler as a non-root user,
 and therefore that binary can be debugged by that same non-root user. At
 the moment, only manual (telnet) interaction is possible. This setup is
-documented in https://wiki.dovecot.org/HowTo/Rootless /
-http://wiki.dovecot.net/SelfContainedTestEnvironments
+documented in https://wiki.dovecot.org/HowTo/Rootless.
 
 Disabling optimizations
 =======================

--- a/source/installation_guide/upgrading/from-0.9-to-1.0.rst
+++ b/source/installation_guide/upgrading/from-0.9-to-1.0.rst
@@ -84,7 +84,7 @@ The port settings are different. The new settings are::
 Log Changes for POP before SMTP
 -------------------------------
 
-If you used `POP-before-SMTP <https://wiki2.dovecot.org/HowTo/PopBSMTPAndDovecot>`_ , the log strings are different. This should work with new versions::
+If you used `POP-before-SMTP <https://wiki.dovecot.org/HowTo/PopBSMTPAndDovecot>`_ , the log strings are different. This should work with new versions::
 
   $s =~ s/^... .. ..:..:.. .* dovecot: (pop3|imap)-login: Login: .+ rip=(\d+\.\d+\.\d+\.\d+),.*$/$2/i;
 

--- a/source/installation_guide/upgrading/from-1.2-to-2.0.rst
+++ b/source/installation_guide/upgrading/from-1.2-to-2.0.rst
@@ -42,7 +42,9 @@ Other major changes
  * Maildir: Permissions for newly created mail files are no longer copied from dovecot-shared file, but instead from the mail directory (e.g. for "foo" mailbox, they're taken from ``~/Maildir/.foo`` directory)
  * dbox: v2.0 format is slightly different, but backwards compatible. The main problem is that v2.0 no longer supports maildir-dbox hybrid resulting from "fast Maildir migration". If you have any Maildir files in your dbox, you need to convert them somehow `some examples <http://dovecot.org/list/dovecot/2010-September/053012.html>`_ . You might also consider using ``dsync`` to get rid of the old unused metadata in your dbox files.
  * Pre-login and post-login CAPABILITY reply is now different. `Dovecot expects clients to recognize new automatically sent capabilities. <http://dovecot.org/list/dovecot/2010-April/048147.html>`_ This should work with all commonly used clients, but some rarely used clients might have problems. Either get the client fixed, or set :ref:`setting-imap_capability` manually.
- * `ManageSieve protocol <http://tools.ietf.org/html/rfc5804>`_ was assigned an official port by IANA: 4190. This is used by Pigeonhole by default now. If you want to listen also on the old 2000 port, see the https://wiki2.dovecot.org/Pigeonhole/ManageSieve/Configuration example.
+ * `ManageSieve protocol <http://tools.ietf.org/html/rfc5804>`_ was assigned an official port by IANA: 4190. This is used by Pigeonhole by default now. If you want to listen also on the old 2000 port, add an ``inet_listener`` with
+   ``port = 2000`` to the ``managesieve-login`` service. See
+   :ref:`service_configuration_inet_listeners`.
  * ``dovecot --exec-mail imap`` has been replaced by simply running "imap" binary. You can also use ``imap -u <username>`` to access other users' mails more easily.
 
 LDA

--- a/source/installation_guide/upgrading/from-2.1-to-2.2.rst
+++ b/source/installation_guide/upgrading/from-2.1-to-2.2.rst
@@ -9,7 +9,8 @@ v2.2 has a couple of changes to settings since v2.1:
 There are also some changes you should be aware of:
 
  * :ref:`plugin-fts-solr` no longer does "hard commits" to the Solr index for performance reasons. `You must do this manually once in a while <plugin-fts_solr_soft_commits>`.
- * When creating home directories, the permissions are copied from the parent directory if it has setgid-bit set. For full details, see https://wiki.dovecot.org/SharedMailboxes/Permissions.
+ * When creating home directories, the permissions are copied from the parent directory if it has setgid-bit set. For full details, see
+   :ref:`admin_manual_permissions_in_shared_mailboxes`.
  * ``doveadm auth`` command was renamed to ``doveadm auth test``
  * IMAP: ID command now advertises server name as Dovecot by default. It was already trivial to guess this from command replies.
  * LDA/LMTP: If saving a mail brings user from under quota to over quota, allow it based on quota_grace setting (default: 10% above quota limit).

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -4319,7 +4319,7 @@ See :ref:`dovecot_ssl_configuration`
 
 The list of SSL cipher suites to use, in order of preference.
 
-See `<https://wiki.openssl.org/index.php/TLS1.3#Ciphersuites>`__
+See https://wiki.openssl.org/index.php/TLS1.3#Ciphersuites
 
 .. _setting-ssl_client_ca_dir:
 

--- a/source/settings/pigeonhole-ext/extprograms.rst
+++ b/source/settings/pigeonhole-ext/extprograms.rst
@@ -46,5 +46,5 @@ Configures the maximum execution time after which the program is forcibly termin
 
 Determines the end-of-line character sequence used for the data piped to external programs.
 The default is currently ``crlf``, which represents a sequence of the carriage return (CR) and line feed (LF) characters.
-This matches the `Internet Message Format (RFC5322) <https://tools.ietf.org/html/rfc5322>`__ and what Sieve itself uses as a line ending.
+This matches the `Internet Message Format (RFC5322) <https://tools.ietf.org/html/rfc5322>`_ and what Sieve itself uses as a line ending.
 Set this setting to ``lf`` to use a single LF character instead. 

--- a/source/settings/pigeonhole-ext/vacation.rst
+++ b/source/settings/pigeonhole-ext/vacation.rst
@@ -14,7 +14,7 @@ Pigeonhole Sieve: Vacation Extension
 
 Specifies the minimum period that can be specified for the ``:days`` and ``:seconds`` tags of the vacation command.
 A minimum of 0 indicates that users are allowed to make the Sieve interpreter send a vacation response message for every incoming message that meets the other reply criteria
-(refer to `RFC5230 <https://tools.ietf.org/html/rfc5230>`__). A value of zero is however not recommended.
+(refer to `RFC5230 <https://tools.ietf.org/html/rfc5230>`_). A value of zero is however not recommended.
 
 
 .. _plugin-sieve-setting-sieve_vacation_max_period:

--- a/source/settings/pigeonhole.rst
+++ b/source/settings/pigeonhole.rst
@@ -197,7 +197,7 @@ See :ref:`pigeonhole_configuration_visible_default_script`.
 
 .. deprecated:: 0.3.1
 
-Directory for :personal `include scripts <http://tools.ietf.org/html/draft-ietf-sieve-include-05>`__ for the include extension.
+Directory for :personal `include scripts <http://tools.ietf.org/html/draft-ietf-sieve-include-05>`_ for the include extension.
 The Sieve interpreter only recognizes files that end with a .sieve extension,
 so the include extension expects a file called name.sieve to exist in the sieve_dir directory for a script called name.
 When using ManageSieve, this is also the directory where scripts are uploaded.
@@ -416,7 +416,7 @@ irrespective of what is configured for this setting.
 
 .. versionremoved:: v0.2
 
-The separator that is expected between the ``:user`` and ``:detail`` address parts introduced by the `subaddress extension <http://tools.ietf.org/html/rfc5233/>`__.
+The separator that is expected between the ``:user`` and ``:detail`` address parts introduced by the `subaddress extension <http://tools.ietf.org/html/rfc5233/>`_.
 This may also be a sequence of characters (e.g. ``--``).
 The current implementation looks for the separator from the left of the localpart and uses the first one encountered.
 The ``:user`` part is left of the separator and the ``:detail`` part is right.

--- a/source/settings/plugin/fts-solr-plugin.rst
+++ b/source/settings/plugin/fts-solr-plugin.rst
@@ -72,4 +72,4 @@ or setting it in solrconfig.xml with
 
 You can also set up a cron job for performing the commits manually.
 
-See: `Solr Full Text Search Indexing <https://wiki.dovecot.org/Plugins/FTS/Solr>`_
+See: :ref:`fts_backend_solr`.

--- a/source/settings/types.rst
+++ b/source/settings/types.rst
@@ -118,4 +118,4 @@ addresses.
 URL
 ---
 
-Special type of :ref:`string` setting. Conforms to `Uniform Resource Locators (URL) (RFC 1738) <https://tools.ietf.org/html/rfc1738>`__.
+Special type of :ref:`string` setting. Conforms to `Uniform Resource Locators (URL) (RFC 1738) <https://tools.ietf.org/html/rfc1738>`_.


### PR DESCRIPTION
Fix issues dealing with original import for wiki (i.e. syntax
differences with rst)
Cleanup broken wiki links
Standardize wiki access style (link to wiki, not wiki2)
Convert links to Sphinx pages that have been moved from the wiki