### PR TITLE
Clarify `client_id` authentication variables

### DIFF
--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -352,8 +352,10 @@ Authentication variables:
 |          |                       |                                                               |
 |          |                       | .. versionadded:: v2.2.19                                     |
 +----------+-----------------------+---------------------------------------------------------------+
-|          | client_id             | Expands to client ID request as IMAP arglist. Needs           |
-|          |                       | imap_id_retain=yes                                            |
+|          | client_id             | If :ref:`setting-imap_id_retain` is enabled this variable is  |
+|          |                       | populated with the client ID request as IMAP arglist.         |
+|          |                       |                                                               |
+|          |                       | For directly logging the ID see :ref:`setting-imap_id_log`.   |
 |          |                       |                                                               |
 |          |                       | .. versionadded:: v2.2.29                                     |
 +----------+-----------------------+---------------------------------------------------------------+

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -1456,8 +1456,11 @@ Example Setting:
 - Default: ``no``
 - Values: :ref:`boolean`
 
-When proxying IMAP connections to other hosts, forward the IMAP ID command
-provided by the client?
+When proxying IMAP connections to other hosts, this variable must be enabled to
+forward the IMAP ID command provided by the client.
+
+This setting enables the ``%{client_id}`` variable for auth processes. See
+:ref:`Auth variables <variables-auth>`.
 
 Example Setting:
 


### PR DESCRIPTION
This PR includes several related clarifications:
- Reword `client_id` authentication variable,
- reword `imap_id_retain` settings variable, and
- add relevant links between `imap_id_retain`, `imap_id_log` (from settings/core) and `client_id` auth varibale (from config_file/config_variable).

DOV-4940