### PR TITLE
settings: Error if setting xref doesn't exist

### DIFF
--- a/source/_ext/dovecot_sphinx.py
+++ b/source/_ext/dovecot_sphinx.py
@@ -10,6 +10,7 @@ from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, Index
 from sphinx.roles import XRefRole
+from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import make_refnode
 
@@ -177,6 +178,8 @@ class DovecotSettingDomain(Domain):
       return make_refnode(builder, fromdocname, todocname, targ, contnode,
                           targ)
     else:
+      logger = logging.getLogger(__name__)
+      logger.warning('Missing cross-reference: %r', target, location=node)
       return None
 
   def get_full_qualified_name(self, node):

--- a/source/configuration_manual/authentication/user_database_extra_fields.rst
+++ b/source/configuration_manual/authentication/user_database_extra_fields.rst
@@ -27,7 +27,7 @@ quota_rule to set per-user quota limits or also plugin-settings).
 
 * ``user``: User can be overridden (normally set in passdb, see
   :ref:`authentication-password_databases`).
-* ``noreplicate``: See :dovecot_plugin:ref:`noreplicate`.
+* ``noreplicate``: See :ref:`replication_configuration`.
 
 The extra fields are also passed to :ref:`post_login_scripting`.
 

--- a/source/configuration_manual/replication.rst
+++ b/source/configuration_manual/replication.rst
@@ -36,6 +36,8 @@ multi-million user installations.
   owner user, and public folders would likely need a per-folder lock or a
   aybe a global public folder lock). There are no plans to fix this.
 
+.. _replication_configuration:
+
 Configuration
 -------------
 

--- a/source/configuration_manual/sieve/plugins/extprograms.rst
+++ b/source/configuration_manual/sieve/plugins/extprograms.rst
@@ -13,7 +13,7 @@ the external programs cannot be chosen arbitrarily; the available
 programs are restricted through administrator configuration.
 
 This plugin is only available for Pigeonhole
-v0.3 and higher (available for Dovecot v2.1). For Pigeonhole 
+v0.3 and higher (available for Dovecot v2.1). For Pigeonhole
 v0.4 this plugin is part of the release. This an evolution of the `Pipe
 plugin <https://wiki.dovecot.org/Pigeonhole/Sieve/Plugins/Pipe>`_
 for Pigeonhole v0.2 and now provides the ``filter`` and ``execute`` commands
@@ -73,19 +73,19 @@ used, for which "<extension>" in the setting name is replaced by either
 ``pipe``, ``filter`` or ``execute`` depending on which extension is
 being configured:
 
-:pigeonhole:ref:`sieve_extension_socket_dir` =
+``sieve_extension_socket_dir`` =
    Points to a directory relative to the Dovecot base_dir where the
    plugin looks for script service sockets.
 
-:pigeonhole:ref:`sieve_extension_bin_dir` =
+``sieve_extension_bin_dir`` =
    Points to a directory where the plugin looks for programs (shell
    scripts) to execute directly and pipe messages to.
 
-:pigeonhole:ref:`sieve_extension_exec_timeout` = 10s
+``sieve_extension_exec_timeout`` = 10s
    Configures the maximum execution time after which the program is
    forcibly terminated.
 
-:pigeonhole:ref:`sieve_extension_input_eol` = crlf
+``sieve_extension_input_eol`` = crlf
    Determines the end-of-line character sequence used for the data piped
    to external programs. The default is currently "crlf", which
    represents a sequence of the carriage return (CR) and line feed (LF)

--- a/source/configuration_manual/sieve/plugins/imapsieve.rst
+++ b/source/configuration_manual/sieve/plugins/imapsieve.rst
@@ -82,7 +82,7 @@ The following settings are recognized the "imap_sieve" plugin:
    server that users must use to upload their Sieve scripts; e.g.,
    ``sieve://sieve.example.com``.
 
-:pigeonhole:ref:`imapsieve_mailboxxxx_name` =
+:pigeonhole:ref:`imapsieve_mailboxXXX_name` =
    This setting configures the name of a mailbox for which administrator
    scripts are configured. The \`XXX' in this setting is a sequence
    number, which allows configuring multiple associations between Sieve
@@ -94,9 +94,9 @@ The following settings are recognized the "imap_sieve" plugin:
    meaning that this setting can apply to multiple or even all ("*")
    mailboxes.
 
-:pigeonhole:ref:`imapsieve_mailboxxxx_before` =
+:pigeonhole:ref:`imapsieve_mailboxXXX_before` =
 
-:pigeonhole:ref:`imapsieve_mailboxxxx_after` =
+:pigeonhole:ref:`imapsieve_mailboxXXX_after` =
    When an IMAP event of interest occurs, these sieve scripts are
    executed before and after any user script respectively. These
    settings each specify the location of a single sieve script. The
@@ -106,7 +106,7 @@ The following settings are recognized the "imap_sieve" plugin:
    together with the user script in which the next script is only
    executed when an (implicit) keep action is executed.
 
-:pigeonhole:ref:`imapsieve_mailboxxxx_causes` =
+:pigeonhole:ref:`imapsieve_mailboxXXX_causes` =
    Only execute the administrator Sieve scripts for the mailbox
    configured with ``imapsieve_mailboxXXX_name`` when one of the listed
    ``IMAPSIEVE``
@@ -115,7 +115,7 @@ The following settings are recognized the "imap_sieve" plugin:
    effect on the user script, which is always executed no matter the
    cause.
 
-:pigeonhole:ref:`imapsieve_mailboxxxx_from` =
+:pigeonhole:ref:`imapsieve_mailboxXXX_from` =
    Only execute the administrator Sieve scripts for the mailbox
    configured with ``imapsieve_mailboxXXX_name`` when the message
    originates from the indicated mailbox. This setting supports

--- a/source/configuration_manual/sieve/usage.rst
+++ b/source/configuration_manual/sieve/usage.rst
@@ -12,21 +12,21 @@ the same way as IMAP clients see them. For example if you want to
 deliver mail to the "Customers" mailbox which exists under "Work"
 mailbox:
 
--  Namespace with :dovecot_core:ref:`prefix="" <namespace_prefix>`, :dovecot_core:ref:`separator=. <namespace_separator>` (Maildir default):
+-  Namespace with :dovecot_core:ref:`prefix="" <namespace/prefix>`, :dovecot_core:ref:`separator=. <namespace/separator>` (Maildir default):
 
 ::
 
    require "fileinto";
    fileinto "Work.Customers";
 
--  Namespace with :dovecot_core:ref:`prefix=INBOX. <namespace_prefix>`, :dovecot_core:ref:`separator=. <namespace_separator>` (Courier migration):
+-  Namespace with :dovecot_core:ref:`prefix=INBOX. <namespace/prefix>`, :dovecot_core:ref:`separator=. <namespace/separator>` (Courier migration):
 
 ::
 
    require "fileinto";
    fileinto "INBOX.Work.Customers";
 
--  Namespace with :dovecot_core:ref:`prefix="" <namespace_prefix>`, :dovecot_core:ref:`separator=/ <namespace_separator>` (mbox, dbox default):
+-  Namespace with :dovecot_core:ref:`prefix="" <namespace/prefix>`, :dovecot_core:ref:`separator=/ <namespace/separator>` (mbox, dbox default):
 
 ::
 

--- a/source/installation_guide/upgrading/from-1.0-to-1.1.rst
+++ b/source/installation_guide/upgrading/from-1.0-to-1.1.rst
@@ -20,7 +20,7 @@ Authentication
 
  * :ref:`authentication-passwd_file`: If you use ``%d`` in args, it no longer means that domain isn't looked up from the passwd-file. You'll need to add ``username_format=%n`` prefix to args (e.g. ``args = username_format=%n /etc/virtual.%d``).
  * Empty or NULL password no longer means "any password is valid". You'll also have to return "nopassword" field.
- * :ref:`authentication-pam`: There's no more ``blocking=yes`` setting, it's now always enabled. If you want to limit the number of lookups done by a dovecot-auth worker, change :dovecot_core:ref:`auth_worker_max_request_count` setting. Setting it to 1 makes it work basically the same as the old ``blocking=no``.
+ * :ref:`authentication-pam`: There's no more ``blocking=yes`` setting, it's now always enabled. If you want to limit the number of lookups done by a dovecot-auth worker, change ``auth_worker_max_request_count`` setting. Setting it to 1 makes it work basically the same as the old ``blocking=no``.
  * :ref:`authentication-passwd`: The problem with passwd lookups is that temporary errors (e.g. LDAP server down) are returned as "user doesn't exist" errors. You may want to try the new :ref:`authentication-nss` userdb.
  * :ref:`authentication-sql` and :ref:`authentication-ldap`: ``user_global_uid`` and ``user_global_gid`` fields have been removed from their config files. Instead you can now use :dovecot_core:ref:`mail_uid` and :dovecot_core:ref:`mail_gid` settings in ``dovecot.conf``. This also means that it's no longer a requirement to specify a userdb at all (a dummy :ref:`authentication-static_user_database` is used internally).
 

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -2247,7 +2247,7 @@ See :ref:`settings` for list of all setting groups.
    multi-server setup that you wish to flush NFS caches, this can be set
    to ``yes`` (in this case, make sure also to use
    :dovecot_core:ref:`mmap_disable` = ``yes`` and
-   :dovecot_core:ref:`fsync_disable` = ``no``).
+   :dovecot_core:ref:`mail_fsync` = ``optimized``).
 
 
 .. dovecot_core:setting:: mail_nfs_storage

--- a/source/settings/pigeonhole-ext/imapsieve.rst
+++ b/source/settings/pigeonhole-ext/imapsieve.rst
@@ -44,7 +44,7 @@ Settings
    :values: APPEND, COPY, FLAG
 
    Only execute the administrator Sieve scripts for the mailbox configured
-   with :pigeonhole:ref:`imapsieve_mailboxxxx_name` when one of the listed
+   with :pigeonhole:ref:`imapsieve_mailboxXXX_name` when one of the listed
    ``IMAPSIEVE`` causes apply.
 
    This has no effect on the user script, which is always executed no matter
@@ -56,7 +56,7 @@ Settings
    :values: @string
 
    Only execute the administrator Sieve scripts for the mailbox configured
-   with :pigeonhole:ref:`imapsieve_mailboxxxx_name` when the message
+   with :pigeonhole:ref:`imapsieve_mailboxXXX_name` when the message
    originates from the indicated mailbox.
 
    This setting supports wildcards with a syntax compatible with the ``IMAP


### PR DESCRIPTION
Non-existent reference, e.g. ":dovecot_core:ref:`foobar`", now gives:

Warning, treated as error:
/home/slusarz/dovecot/documentation/source/admin_manual/logging.rst:9:Missing cross-reference: 'foobar'
make: *** [Makefile:19: html] Error 2
