### PR TITLE
Guard against forks without deploy keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,6 @@ jobs:
         RSYNC_OPTIONS: -azr --delete
         RSYNC_TARGET: docs@doc.dovecot.org:public_html/.
         RSYNC_BASEDIR: /_build/.
+      if: env.DEPLOY_KEY
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
For [reasons](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), you can't use `secrets` in `if`, but you can put a secret into an `env` and then use `env` in the `if`.