### PR TITLE
configuration_manual/mail_location: Update DIRNAME/FULLDIRNAME keys

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -544,6 +544,7 @@ INBO
 inbox
 inboxes
 INCLUDERC
+INDEXCACHE
 indexfiles
 INDEXPVT
 inet

--- a/source/configuration_manual/mail_location/index.rst
+++ b/source/configuration_manual/mail_location/index.rst
@@ -131,33 +131,34 @@ Key                Value Description
                    directories are stored. The default is empty unless
                    otherwise described in the mailbox format pages.
 
+``DIRNAME``        Specifies the directory name used for mailbox directories,
+                   or in the case of mbox specifies the mailbox message file
+                   name.
+
+                   The :ref:`sdbox and mdbox <dbox_settings>` formats use
+                   ``DIRNAME=dbox-Mails`` by default.
+
+                   .. note:: ``DIRNAME`` is not used for index or control
+                             directories, consider using ``FULLDIRNAME``
+                             instead.
+
 ``FULLDIRNAME``    Specifies the directory name used for mailbox, index, and
                    control directory paths. See the individual mailbox format
-                   pages for further information. This key replaced the
-                   deprecated ``DIRNAME`` key.
+                   pages for further information.
+
+                   .. note:: Bug: Before v2.3.19 folder renaming was broken
+                             when using ``FULLDIRNAME`` together with
+                             ``INDEX``, ``INDEXPVT``, ``INDEXCACHE`` or
+                             ``CONTROL``. Renaming a parent folder lost the
+                             index/control files for all of its child folders,
+                             which with some mailbox formats lost the mails
+                             until force-resync was used.
 
                    .. versionadded:: v2.2.8
 
 ``ALT``            Specifies the
                    :ref:`alternate storage <dbox_settings_alt_storage>` path.
 ================== =============================================================
-
-Deprecated Keys
----------------
-
-============ ================ ==============================================
-Key          Replaced By      Value Description
-============ ================ ==============================================
-``DIRNAME``  ``FULLDIRNAME``  Specifies the directory name used for mailbox
-                              directories, or in the case of mbox specifies
-                              the mailbox message file name.
-
-                              .. note:: DIRNAME is not used for index or
-                                        control directories, while
-                                        ``FULLDIRNAME`` is.
-
-                              .. deprecated:: v2.2.8
-============ ================ ==============================================
 
 Variables
 ---------


### PR DESCRIPTION
- Move `DIRNAME` back to main keys table,
- change `DIRNAME` deprecation version, and
- communicate bug when renaming folders using `FULLDIRNAME` together
  with certain other options.