### PR TITLE
configuration_manual/authentication: Remove shadow passdb driver

### DIFF
--- a/source/admin_manual/system_users_used_by_dovecot.rst
+++ b/source/admin_manual/system_users_used_by_dovecot.rst
@@ -137,9 +137,8 @@ default is to use root, because it's guaranteed to have access to all the
 password databases. If you don't need this, you should change it to
 ``$default_internal_user``.
 
-:ref:`authentication-pam` and :ref:`authentication-shadow` passdbs are usually
-configured to read ``/etc/shadow`` file. Even this doesn't need root access if
-the file is readable by shadow group:
+:ref:`authentication-pam` is usually configured to read ``/etc/shadow`` file.
+Even this doesn't need root access if the file is readable by shadow group:
 
 .. code-block:: none
 

--- a/source/configuration_manual/authentication/master_users.rst
+++ b/source/configuration_manual/authentication/master_users.rst
@@ -84,9 +84,6 @@ Example configuration:
     master = yes
     result_success = continue
   }
-  passdb {
-    driver = shadow
-  }
   userdb {
     driver = passwd
   }

--- a/source/configuration_manual/authentication/password_databases_passdb.rst
+++ b/source/configuration_manual/authentication/password_databases_passdb.rst
@@ -103,8 +103,6 @@ lookup can return:
    databases (if prefix is specified), but that is of course incompatible with
    all other tools using/modifying the passwords.
 
-* **VPopMail**: External software used to handle virtual domains.
-
 **Databases** that support looking up everything:
 
 * **Passwd-file**: ``/etc/passwd``-like file in specified location. See

--- a/source/configuration_manual/authentication/password_databases_passdb.rst
+++ b/source/configuration_manual/authentication/password_databases_passdb.rst
@@ -92,12 +92,10 @@ lookup can return:
 
 **Databases** that support looking up only passwords, but no user or extra fields:
 
-* **Passwd-file**: ``/etc/passwd-like`` file in specified location. See
+* **Passwd-file**: ``/etc/passwd``-like file in specified location. See
   :ref:`authentication-passwd`.
 * **Passwd**: System users (NSS, ``/etc/passwd``, or similar). See
   :ref:`authentication-password_schemes`.
-* **Shadow**: Shadow passwords for system users (NSS, ``/etc/shadow`` or
-  similar). See :ref:`authentication-shadow`.
 
  * Dovecot supports reading all :ref:`authentication-password_schemes` from passwd and shadow
    databases (if prefix is specified), but that is of course incompatible with
@@ -264,7 +262,6 @@ The result values that can be used:
   static_password_database
   password_schemes
   user_extra_field
-  shadow
   passwd_file
   ldap
   sql

--- a/source/configuration_manual/authentication/password_schemes.rst
+++ b/source/configuration_manual/authentication/password_schemes.rst
@@ -104,7 +104,7 @@ setting in ``dovecot-sql.conf.ext``
 :ref:`authentication-passwd_file` : CRYPT is used
 by default, but can be changed with ``scheme`` parameter in passdb args.
 
-:ref:`authentication-passwd`, :ref:`authentication-shadow`, ``vPopMail``: CRYPT is used by default
+:ref:`authentication-passwd`, :ref:`authentication-shadow`: CRYPT is used by default
 and can't be changed currently.
 
 :ref:`authentication-pam`, :ref:`authentication-bsdauth`, :ref:`authentication-checkpassword`: Dovecot never even sees the

--- a/source/configuration_manual/authentication/password_schemes.rst
+++ b/source/configuration_manual/authentication/password_schemes.rst
@@ -104,8 +104,7 @@ setting in ``dovecot-sql.conf.ext``
 :ref:`authentication-passwd_file` : CRYPT is used
 by default, but can be changed with ``scheme`` parameter in passdb args.
 
-:ref:`authentication-passwd`, :ref:`authentication-shadow`: CRYPT is used by default
-and can't be changed currently.
+:ref:`authentication-passwd`: CRYPT is used by default and can't be changed currently.
 
 :ref:`authentication-pam`, :ref:`authentication-bsdauth`, :ref:`authentication-checkpassword`: Dovecot never even sees the
 password with these databases, so Dovecot has nothing to do with what password

--- a/source/configuration_manual/authentication/shadow.rst
+++ b/source/configuration_manual/authentication/shadow.rst
@@ -4,6 +4,10 @@
 Shadow
 =======
 
+.. versionremoved:: v2.4.0;v3.0.0
+
+.. warning:: This plugin has been removed. Use :ref:`authentication-pam` instead.
+
 Works at least with Linux and Solaris, but nowadays :ref:`authentication-pam` is usually
 preferred to this.
 

--- a/source/configuration_manual/authentication/user_databases_userdb.rst
+++ b/source/configuration_manual/authentication/user_databases_userdb.rst
@@ -60,7 +60,6 @@ Currently supported user databases are:
 * **SQL**: SQL database (PostgreSQL, MySQL, SQLite). See :ref:`authentication-sql`
 * **Dict**: Dict key-value database (Redis, memcached, etc.). See :ref:`authentication-dict`.
 * **Static**: Userdb information generated from a given template. See :ref:`authentication-static_user_database`.
-* **VPopMail**: External software used to handle virtual domains.
 * **Prefetch**: This assumes that the passdb already returned also all the
   required user database information. See :ref:`authentication-prefetch_userdb`
 * **Lua**: Lua script for authentication. See :ref:`authentication-lua_based_authentication`.


### PR DESCRIPTION
- Mark shadow passdb driver as deprecated, and
- remove unnecessary references to removed auth driver.