### PR TITLE
configuration_manual/mail_location: Remove DIRNAME key

### DIFF
--- a/source/configuration_manual/mail_location/index.rst
+++ b/source/configuration_manual/mail_location/index.rst
@@ -131,31 +131,19 @@ Key                Value Description
 
 ``FULLDIRNAME``    Specifies the directory name used for mailbox, index, and
                    control directory paths. See the individual mailbox format
-                   pages for further information. This key replaced the
-                   deprecated ``DIRNAME`` key.
+                   pages for further information.
+
+                   .. note:: Bug: Before v2.4.0/v3.0.0 when using
+                             ``FULLDIRNAME`` together with ``INDEX``,
+                             ``INDEXPVT``, ``INDEXCACHE`` or ``CONTROL``
+                             options renaming the parent folder causes its
+                             child folders to lose all messages.
 
                    .. versionadded:: v2.2.8
 
 ``ALT``            Specifies the
                    :ref:`alternate storage <dbox_settings_alt_storage>` path.
 ================== =============================================================
-
-Deprecated Keys
----------------
-
-============ ================ ==============================================
-Key          Replaced By      Value Description
-============ ================ ==============================================
-``DIRNAME``  ``FULLDIRNAME``  Specifies the directory name used for mailbox
-                              directories, or in the case of mbox specifies
-                              the mailbox message file name.
-
-                              .. note:: DIRNAME is not used for index or
-                                        control directories, while
-                                        ``FULLDIRNAME`` is.
-
-                              .. deprecated:: v2.2.8
-============ ================ ==============================================
 
 Variables
 ---------


### PR DESCRIPTION
Remove `DIRNAME` key - which has been deprecated by `FULLDIRNAME` -
description with removal from code.

JIRA: DOV-5022

This is PR is specific to v3.0. #401 has similar changes that are specific to the current version at creation time.