### PR TITLE
Dov 5011/remove dsync command

### DIFF
--- a/source/admin_manual/error_codes.rst
+++ b/source/admin_manual/error_codes.rst
@@ -1,7 +1,7 @@
 .. _doveadm_error_codes:
 
-Doveadm (Dsync) Error/Exit Codes
-================================
+Doveadm Error/Exit Codes
+========================
 
 Dovecot uses standard libc error codes. These codes are most useful to
 determine why dsync mail migration failed.

--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -72,7 +72,7 @@ Variables that are work nearly everywhere where there is a username:
 +----------+----------------+---------------------------------------------------------------+
 | %d       | domain         | domain part in user@domain, empty if user with no domain      |
 +----------+----------------+---------------------------------------------------------------+
-| %s       | service        | imap, pop3, smtp, lda (and doveadm, dsync, etc.)              |
+| %s       | service        | imap, pop3, smtp, lda (and doveadm, etc.)                     |
 +----------+----------------+---------------------------------------------------------------+
 |          | session        | session ID for this client connection (unique for 9 years)    |
 +----------+----------------+---------------------------------------------------------------+

--- a/source/developer_manual/design/mailbox_list.rst
+++ b/source/developer_manual/design/mailbox_list.rst
@@ -23,7 +23,7 @@ functions are:
 Mailbox list code also internally creates and updates mailbox changelog
 (in ``dovecot.mailbox.log`` file), which keeps track of mailbox
 deletions, renames and subscription changes. This is primarily useful
-for dsync utility.
+when running the ``doveadm sync`` command.
 
 .. _design_mailbox_names:
 

--- a/source/installation_guide/upgrading/from-2.3-to-3.0.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-3.0.rst
@@ -81,6 +81,10 @@ Removed features and their replacements
 | dsync: Remove -D parameter                                 | Parameter for disabling mailbox rename syncing removed.                                  |
 |                                                            | It hasn't been necessary for a long time, and it is broke                                |
 +------------------------------------------------------------+------------------------------------------------------------------------------------------+
+| dsync                                                      | Use `doveadm` instead.                                                                   |
+|                                                            | `dsync` has been a symlink to `doveadm` already, this release removed the symlink        |
+|                                                            | completely.                                                                              |
++------------------------------------------------------------+------------------------------------------------------------------------------------------+
 | :dovecot_core:ref:`login_access_sockets                    | Use :ref:`authentication-lua_based_authentication` instead.                              |
 | <login_access_sockets>`                                    | Dovecot will fail to start if this setting is present in configuration.                  |
 +------------------------------------------------------------+------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Update the documentation to remove direct references to the `dsync` command (or symlink to `doveadm`).
Most other remaining references are mainly due to:
- Describing the design/operation/general idea behind the `doveadm sync` operation (aptly named `dsync`), or
- old update guides that explicitly state `dsync` because that still existed.

Closes DOV-5011