### PR TITLE
DOV-5043: Remove references to obsolete wiki

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -64,6 +64,7 @@ authpriv
 authtok
 authuser
 authz
+autoconf
 autocreate
 autocreated
 Autocreation
@@ -136,6 +137,7 @@ CApath
 cas
 Cazabon
 cbc
+ccs
 cdb
 cdmi
 certbot
@@ -154,6 +156,7 @@ CHECKSCRIPT
 chgrp
 chmod
 chown
+chrony
 chroot
 chrooting
 CIDR
@@ -163,6 +166,7 @@ cipe
 Ciphersuites
 CJK
 cleartext
+clockspeed
 closedir
 clucene
 clusterfs
@@ -191,6 +195,7 @@ courierimapuiddb
 cov
 CPID
 cpp
+CPPFLAGS
 cql
 cqlsh
 crlf
@@ -256,6 +261,7 @@ dictmap
 dictrevmap
 dicts
 Diffie
+digestmd
 DIRNAME
 dirnamename
 dirpath
@@ -268,6 +274,7 @@ DLLVM
 dlog
 dlua
 DMARC
+dnotify
 dnpass
 dns
 docidx
@@ -351,6 +358,7 @@ eokb
 eol
 eperm
 epk
+epoll
 epub
 EROFS
 errno
@@ -419,6 +427,7 @@ fstat
 fsuid
 fsync
 fsyncing
+ftp
 fts
 ftscache
 FULLDIRNAME
@@ -474,10 +483,13 @@ halon
 haproxy
 hara
 hardcoded
+hardlink
+hardlinking
 hardlinks
 hasfrop
 hashmap
 hatv
+haxx
 hba
 hda
 HDD
@@ -495,11 +507,13 @@ homedir
 homepage
 hostaddr
 hostchange
+HOSTDOMAIN
 hostname
 Hotspot
 howto
 htaccess
 htbp
+htdigest
 htiweb
 htm
 html
@@ -531,6 +545,7 @@ imaptest
 imapwiki
 IMDS
 imem
+imtest
 INBO
 inbox
 inboxes
@@ -547,6 +562,7 @@ ino
 inode
 inodetofile
 inotify
+inotifytools
 INTERNALDATE
 internalfail
 interoperable
@@ -597,6 +613,7 @@ kuromoji
 kuserok
 KVM
 LANMAN
+largefile
 lasthost
 lastlogin
 launchd
@@ -627,12 +644,16 @@ libexec
 libexpat
 libexttextcat
 libicu
+libkrb
+libldap
 liblib
 liblz
 liblzma
+libmysqlclient
 libpam
 libpq
 libsodium
+libsqlite
 libstemmer
 libtool
 libuv
@@ -742,6 +763,7 @@ messageguid
 metacache
 metacpan
 metadata
+microsites
 microsoft
 middleware
 millisecs
@@ -832,6 +854,7 @@ noscheme
 nosearch
 noselect
 nosep
+nosuid
 notfound
 notifempty
 notwhat
@@ -843,7 +866,9 @@ nsend
 nsname
 nss
 ntlm
+ntp
 ntpd
+ntpdate
 nullok
 nuls
 nulsoe
@@ -892,6 +917,7 @@ oxbuildkey
 oxpedia
 oxuser
 pacman
+pandoc
 papersize
 params
 passdb
@@ -906,11 +932,14 @@ pfs
 PGP
 pgsql
 php
+phtml
 pid
 pidfile
+pidof
 Piljk
 pkcs
 pkey
+pkgconfig
 pki
 plaa
 plist
@@ -1014,6 +1043,7 @@ rfc
 rhel
 RHu
 RLIMIT
+rml
 Rnotation
 Roboto
 roundcube
@@ -1061,6 +1091,7 @@ secretpassword
 seealso
 seekable
 SELEC
+selfservice
 semanage
 sendfile
 sendmail
@@ -1080,6 +1111,7 @@ setra
 setrecursionlimit
 setsid
 SFTP
+sfw
 sgid
 SHAREDDIR
 sharedmail
@@ -1110,6 +1142,7 @@ solib
 solr
 solrcloud
 solrconfig
+somaxconn
 somedict
 SOURCEDIR
 sourceforge
@@ -1146,6 +1179,7 @@ ssd
 ssh
 ssha
 ssl
+ssldir
 sstable
 stackbuf
 standalone
@@ -1191,6 +1225,8 @@ Subtables
 subvalue
 sudo
 sudoers
+sunfreeware
+sunsite
 SUSE
 svbin
 swapoff
@@ -1267,9 +1303,11 @@ tostring
 transitioning
 trie
 Trojita
+Tru
 tscript
 ttl
 tukaani
+tuxfamily
 txn
 TYPECHECK
 typedef
@@ -1372,10 +1410,12 @@ vlan
 vlast
 vmail
 vmback
+vmware
 VMware
 vname
 vnd
 VOLATILEDIR
+vpopmail
 vpv
 VRFY
 vsize
@@ -1383,6 +1423,7 @@ vsz
 wal
 wbytes
 wchar
+Wcry
 weakforced
 webmail
 webpage
@@ -1408,6 +1449,8 @@ xattr
 XBAR
 xchange
 xclient
+Xen
+xenproject
 Xes
 XFOO
 xfs

--- a/source/admin_manual/chrooting.rst
+++ b/source/admin_manual/chrooting.rst
@@ -1,0 +1,72 @@
+.. _chrooting:
+
+=========
+Chrooting
+=========
+
+Traditionally chrooting has been done to run the whole server within a
+single chroot. This is also possible with Dovecot, but it requires
+manually setting up the chroot and it can be a bit tricky. Dovecot
+however supports internally running different parts of it in different
+chroots:
+
+-  Login processes (imap-login, pop3-login) are chrooted by default into
+   an empty non-writable directory.
+
+-  Authentication process (dovecot-auth) can be chrooted by setting
+   ``chroot=<path>`` inside ``service auth`` and/or
+   ``service auth-worker`` sections. This could be a good idea to change
+   if you're not using a passdb or userdb that needs to access files
+   outside of the chroot. Also make sure not to run the auth process as
+   root then.
+
+-  Mail processes (imap, pop3) can be made to chroot in different ways.
+   See below.
+
+Security problems
+^^^^^^^^^^^^^^^^^
+
+If chrooting is used incorrectly, it allows local users to gain root
+privileges. This is possible by hardlinking setuid binaries inside the
+chroot jail and tricking them. There are at least two possibilities:
+
+1. Hardlink ``/bin/su`` inside the chroot and create your own
+   ``<chroot>/etc/passwd``. Then simply run ``su root``.
+
+2. Create your own ``<chroot>/lib/libc.so`` and run any setuid binary.
+
+Of course both of these require that the setuid binary can be run inside
+the chroot. This isn't possible by default. Either user would have to
+find a security hole from Dovecot, or the administrator would have had
+to set up something special that allows running binaries.
+
+In any case it's a good idea not to allow users to hardlink setuid
+binaries inside the chroots. The safest way to do this is to mount the
+filesystem with "nosuid" option.
+
+Mail process chrooting
+^^^^^^^^^^^^^^^^^^^^^^
+
+Due to the potential security problem described above, Dovecot won't
+chroot mail processes to directories which aren't listed in
+:dovecot_core:ref:`valid_chroot_dirs` setting. For example if your users
+may be chrooting under ``/var/mail/<user>/`` and ``/home/<user>/``, use:
+
+.. code-block:: none
+
+   valid_chroot_dirs = /var/mail:/home
+
+You can chroot all users globally into the same directory by using
+:dovecot_core:ref:`mail_chroot` setting. For example:
+
+.. code-block:: none
+
+   mail_chroot = /home
+
+You can also make userdb return a chroot. There are two ways to do that:
+
+1. Make userdb return ``chroot=<path>`` field.
+
+2. Insert "/./" inside the returned home directory, eg.:
+   ``home=/home/./user`` to chroot into ``/home``, or
+   ``home=/home/user/./`` to chroot into ``/home/user``.

--- a/source/admin_manual/errors/chgrp_no_perm.rst
+++ b/source/admin_manual/errors/chgrp_no_perm.rst
@@ -1,0 +1,28 @@
+.. _errors_chgrp_no_perm:
+
+====================================
+Change Group Operation Not Permitted
+====================================
+
+.. code-block:: none
+
+   imap(user): Error: chown(/home/user/mail/.imap/INBOX, group=12(mail)) failed: Operation not permitted (egid=1000(user), group based on /var/mail/user - see https://doc.dovecot.org/admin_manual/errors/chgrp_no_perm/)
+
+This means that Dovecot tried to copy ``/var/mail/user`` file's group (mail) to
+the index file directory it was creating (``/home/user/mail/.imap/INBOX``), but
+the process didn't belong to the mail group, so it failed. This is important
+for preserving access permissions with :ref:`shared_mailboxes`. Group copying
+is done only when it actually changes the access permissions; for example with
+0600 or 0666 mode the group doesn't matter at all, but with 0660 or 0640 it
+does.
+
+To solve this problem you can do only one of two things:
+
+1. If the group doesn't actually matter, change the permissions so that
+   the group isn't copied (e.g. ``chmod 0600 /var/mail/*``, see
+   :ref:`Mbox Mailbox Format <mbox_mbox_format>`).
+
+2. Give the mail process access to the group (e.g. ``mail_access_groups=mail``
+   setting). However, this is dangerous. `It allows users with shell access to
+   read other users' INBOXes
+   <http://dovecot.org/list/dovecot-news/2008-March/000060.html>`_.

--- a/source/admin_manual/errors/index.rst
+++ b/source/admin_manual/errors/index.rst
@@ -1,0 +1,11 @@
+.. _errors:
+
+======
+Errors
+======
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   *

--- a/source/admin_manual/errors/socket_unavailable.rst
+++ b/source/admin_manual/errors/socket_unavailable.rst
@@ -1,0 +1,76 @@
+.. _errors_socket_unavailable:
+
+============================================
+UNIX Socket Resource Temporarily Unavailable
+============================================
+
+Commonly visible as:
+
+.. code-block:: none
+
+   imap-login: Error: net_connect_unix(imap) failed: Resource temporarily unavailable
+
+This means that there are more imap-login processes trying to connect to
+the "imap" UNIX socket than there are imap processes accepting the
+connections. The kernel's connection listener queue got full and it
+started rejecting further connections. So what can be done about it?
+
+Wrong service settings
+^^^^^^^^^^^^^^^^^^^^^^
+
+This can happen if ``service imap { client_limit }`` is set to anything
+else than 1. IMAP (and POP3 and other mail) processes do disk IO, lock
+waiting and such, so if all the available imap processes are stuck
+waiting on something, they can't accept new connections and they queue
+up in the kernel. For mail processes only ``client_limit=1`` is recommended.
+
+It can also happen if ``service imap { process_limit }`` is reached.
+Dovecot logs a warning if process_limit or client_limit is reached.
+
+Out of file descriptors
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If the "ulimit -n" is too low, kernel stops notifying the process about
+incoming connections. Make sure that the limit is at least as high as
+the client_limit. Dovecot also internally checks this, and if it's too
+low it writes a warning to stderr at startup (and to log in v2.2.33+).
+
+Note that Dovecot is not using "dovecot" user's or PAM's limits in
+general. Make sure the limits are correct with:
+``cat /proc/`pidof dovecot`/limits``
+
+Master process busy
+^^^^^^^^^^^^^^^^^^^
+
+Dovecot master process forks all of the new processes. If it's using
+100% CPU, it doesn't have time to fork enough new processes. Even if
+it's not constantly using 100% CPU there may be fork bursts where it
+temporarily gets too busy. The solution is to make it do less work by
+forking less processes:
+
+-  Most importantly switch to :ref:`high-performance login process
+   mode <login_processes>`. This alone might be enough.
+
+-  You can also switch (most of the) other commonly forked processes to
+   be reused. For example ``service imap { service_count = 100 }``
+   reuses the imap process for 100 different IMAP connections before it
+   dies. This is useful mainly for imap, pop3 and managesieve services.
+   It's better to avoid using ``service_count=0`` (unlimited) in case
+   there are memory leaks.
+
+-  You can pre-fork some idling processes to handle bursts with
+   ``service { process_min_avail }``. Before v2.3.15 the pre-forking was
+   creating processes too slowly, often practically disabling the
+   pre-forking during the times when they would have been most useful.
+
+See :ref:`Services <service_configuration>` before changing any service
+settings. Some services require specific values to work correctly.
+
+Listener queue size
+^^^^^^^^^^^^^^^^^^^
+
+Dovecot uses ``service { client_limit } * service { process_limit }`` as the
+listener queue size. Dovecot v2.2.25 and older also had a hardcoded
+maximum of 511, while later versions have no upper limit. Most OSes use
+an even lower limit, typically 128. In Linux you can increase this from
+``/proc/sys/net/core/somaxconn``.

--- a/source/admin_manual/errors/time_moved_backwards.rst
+++ b/source/admin_manual/errors/time_moved_backwards.rst
@@ -1,0 +1,103 @@
+.. _errors_time_moved_backwards:
+
+==========================
+Time moved backwards error
+==========================
+
+Dovecot isn't very forgiving if your system's time moves backwards.
+There are usually two possibilities why it's moving backwards:
+
+1. You're running ``ntpdate`` periodically. This isn't a good idea.
+
+2. You're using some kind of a virtual server and you haven't configured
+   it right (or it's buggy).
+
+Moving time backwards might cause various problems (see below), so
+Dovecot versions older than v2.0 don't even try to handle the situation.
+
+Time synchronization
+^^^^^^^^^^^^^^^^^^^^
+
+There are two choices for synchronizing your clock:
+
+1. Use `ntpd <http://www.ntp.org/>`_. It periodically checks the
+   current time from NTP server and slows down or speeds up the clock if
+   necessary. Unlike ntpdate, it doesn't just move the time forwards or
+   backwards (unless the difference is large).
+
+   -  If the time difference is too large for ntpd and it "steps", then
+      use "-x" as a command line option for ntpd or use "tinker step 0"
+      in ``/etc/ntp.conf``.
+
+      -  This shows up in logs as:
+         ``ntpd[17697]: time reset -2.075483 s``
+
+2. If ntpd doesn't work well (e.g. a bad network connection), you can
+   use `clockspeed <http://cr.yp.to/clockspeed.html>`_ or
+   `chrony <https://chrony.tuxfamily.org/>`_ as well.
+
+In some systems ntpd/ntpdate is run at boot, but only after Dovecot has
+started. That can cause Dovecot to die immediately. If you have this
+problem, fix your init scripts to run ntpd/ntpdate first, before
+starting Dovecot. Also, seriously consider running ntp-wait before
+starting Dovecot.
+
+Bugs/Issues
+^^^^^^^^^^^
+
+-  With Xen you should run ntpd only in dom0. Other domains should
+   synchronize time automatically (see `this Xen
+   FAQ <https://wiki.xenproject.org/wiki/Xen_Common_Problems>`_ and `this
+   thread <http://dovecot.org/list/dovecot/2009-October/043301.html>`_).
+
+-  With VMware you follow the guidelines at the `VMware knowledge
+   base <http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1006427>`_.
+
+-  `Time moved backwards by 4398
+   seconds <http://www.dovecot.org/list/dovecot/2008-June/031548.html>`_?
+   Buggy kernel/hardware.
+
+What about Daylight Saving/Summer time?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On Unix-like systems, time is stored internally as the number of seconds
+since January 1, 1970, 00:00:00 UTC (see `Unix_time on
+Wikipedia <http://www.wikipedia.com/wiki.phtml?title=Unix_time#>`_); concepts
+such as time zones and daylight saving time are applied in user space by the C
+library, and will normally not have an impact on Dovecot's behavior.
+
+Dovecot shouldn't just die!
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dovecot v2.0 finally tries to handle this a bit more gracefully. Its
+behavior when time moves backwards is:
+
+-  Existing imap and pop3 processes either sleep or die, just like with
+   older versions
+
+-  Master process stops creating new processes until either the original
+   time is reached, or after a maximum wait of 3 minutes.
+
+-  Other processes log a warning, but do nothing else.
+
+-  Timeouts are updated so that the timeout is executed approximately at
+   the original intended time.
+
+Dovecot v2.0 also notices when time unexpectedly jumps forwards. In that
+situation it logs a warning and also updates timeouts.
+
+The reason why imap/pop3 processes get killed and new ones can't be
+created for a while is to avoid problems related to timestamps. Some
+issues are:
+
+-  Uniqueness of Maildir filenames and dbox global unique identifiers
+   relies on a growing timestamp.
+
+-  Dotlock files' staleness is detected by looking at its mtime.
+
+-  Timestamps are stored internally all around in memory (as well as in
+   index files) and compared to current time. Those checks may or may
+   not be buggy if current time shrinks.
+
+While killing mail processes doesn't fully solve any of those issues,
+they're at least less likely to happen then.

--- a/source/configuration_manual/authentication/digest-md5.rst
+++ b/source/configuration_manual/authentication/digest-md5.rst
@@ -1,0 +1,81 @@
+.. _authentication-digestmd5:
+
+==========
+Digest-MD5
+==========
+
+Digest-MD5 has two things that make it special and which can cause
+problems:
+
+-  Instead of using user@domain usernames, it supports **realms**.
+-  User name and realm are part of the MD5 hash that's used for
+   authentication.
+
+For these and other reasons `Digest-MD5 has been
+obsoleted <https://www.ietf.org/rfc/rfc6331.html>`_ by
+`SCRAM <https://www.ietf.org/rfc/rfc5802.html>`_.
+
+Realms
+^^^^^^
+
+Realms are an integral part of Digest-MD5. You will need to specify
+realms you want to advertise to the client in the config file:
+
+.. code-block:: none
+
+   auth_realms = example.com another.example.com foo
+
+The realms don't have to be domains. All listed realms are presented to
+the client and it can select to use one of them. Some clients always use
+the first realm. Some clients use your domain name, whenever given more
+than one realm to choose from. Even if this was NOT one of the choices
+you provided (KMail, others?). In both cases the user never sees the
+advertised realms.
+
+Note that the (badly named) :dovecot_core:ref:`auth_default_realm` setting
+doesn't work well with Digest-MD5. It doesn't actually specify a default realm
+or have anything to do with Digest-MD5 realms, but rather it appends
+``@auth_default_realm`` to the username if it's missing the ``@domain`` part.
+This will break Digest-MD5 authentication, because the client didn't use the
+``@auth_default_realm`` part in the hash calculations.
+
+DIGEST-MD5 scheme
+^^^^^^^^^^^^^^^^^
+
+Password must be stored in either plaintext or with DIGEST-MD5 scheme.
+See :ref:`authentication-password_schemes`.
+
+The Digest is the MD5 sum of the string "user:realm:password". So for
+example if you want to log in as ``user`` with password ``pass`` and the
+realm should be ``example.com`` (usually not provided by the user, see
+above), create the digest with:
+
+.. code-block:: none
+
+   % echo -n "user:example.com:pass" | md5sum c19c4c6e32f9d8026b26ba77c21fb8eb  -
+
+And save it as
+
+.. code-block:: none
+
+   user@example.com:c19c4c6e32f9d8026b26ba77c21fb8eb
+
+Note that if you're using DIGEST-MD5 scheme to store the passwords, you
+can't change the users' names or realms in any way or the authentication
+will fail because the MD5 sums don't match. Also not that this is
+different from what Apache does with HTTP AUTH Digest. There it would be
+``user:example.com:c19c4c6e32f9d8026b26ba77c21fb8eb`` and is created
+with ``htdigest``.
+
+Testing
+^^^^^^^
+
+You can use ``imtest`` from `Cyrus SASL <https://www.cyrusimap.org/sasl/>`_
+library to test an IMAP connection:
+
+.. code-block:: none
+
+   # With realm:
+   imtest -a user -r example.com
+   # Without realm:
+   imtest -a user@example.com

--- a/source/configuration_manual/authentication/winbind.rst
+++ b/source/configuration_manual/authentication/winbind.rst
@@ -1,0 +1,36 @@
+.. _authentication-winbind:
+
+==================
+Winbind mechanisms
+==================
+
+Dovecot supports NTLM and GSS-SPNEGO authentication mechanisms using
+`Samba <http://www.samba.org>`_'s winbind daemon. It is useful when you
+need to authenticate users against a Windows domain (either AD or NT).
+
+By default NTLM mechanism is handled internally. You can use winbind
+instead by setting:
+
+.. code-block:: none
+
+   auth_use_winbind = yes
+
+The usernames, returned by winbind, can contain some domain part (either
+"DOMAIN\user" or "user@example.com"). Such usernames are always
+transformed to the form of "user@domain". To strip domain part (to
+obtain corresponding local username, for example), set:
+
+.. code-block:: none
+
+   auth_username_format = %n
+
+Dovecot needs path to Samba's ``ntlm_auth`` binary to perform the
+authentication. You can change the path with:
+
+.. code-block:: none
+
+   auth_winbind_helper_path = /usr/bin/ntlm_auth
+
+Dovecot currently does blocking lookups, so if ``ntlm_auth`` is slow on
+responding (e.g. network problems), Dovecot blocks all other
+authentication requests until it's finished.

--- a/source/installation_guide/dovecot_community_repositories/compiling_source.rst
+++ b/source/installation_guide/dovecot_community_repositories/compiling_source.rst
@@ -1,0 +1,122 @@
+.. _compiling_source:
+
+==============================
+Compiling Dovecot From Sources
+==============================
+
+For most people it is enough to do:
+
+.. code-block:: none
+
+   ./configure
+   make
+   sudo make install
+
+That installs Dovecot under the ``/usr/local`` directory. The
+configuration file is in ``/usr/local/etc/dovecot.conf``. Logging goes
+to syslog's mail facility by default, which typically goes to
+``/var/log/mail.log`` or something similar. If you are in a hurry, you
+can then jump to :ref:`QuickConfiguration <quick_configuration>`.
+
+If you have installed some libraries into locations which require
+special include or library paths, you can pass them in the ``CPPFLAGS``
+and ``LDFLAGS`` environment variables. For example:
+
+.. code-block:: none
+
+   CPPFLAGS="-I/opt/openssl/include" LDFLAGS="-L/opt/openssl/lib" ./configure
+
+You'll need to create two users for Dovecot's internal use:
+
+-  **dovenull**: Used by untrusted imap-login and pop3-login processes
+   (default_login_user setting).
+
+-  **dovecot**: Used by slightly more trusted Dovecot processes
+   (default_internal_user setting).
+
+Both of them should also have their own **dovenull** and **dovecot**
+groups. See :ref:`UserIds <system_users_used_by_dovecot>` for more information.
+
+Compiling Dovecot From Git
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you got Dovecot from Git, for instance with
+
+.. code-block:: none
+
+   git clone https://github.com/dovecot/core.git dovecot
+
+you will first need to run ``./autogen.sh`` to generate the
+``configure`` script and some other files. This requires that you have
+the following software/packages installed:
+
+-  ``wget``
+
+-  ``autoconf``
+
+-  ``automake``
+
+-  ``libtool``
+
+-  ``pkg-config``
+
+-  ``gettext``
+
+-  ``pandoc`` (not strictly required - you can avoid it by using:
+   ``PANDOC=false ./configure``)
+
+-  GNU make.
+
+It is advisable to add ``--enable-maintainer-mode`` to the ``configure``
+script. Thus:
+
+.. code-block:: none
+
+   ./autogen.sh
+   ./configure --enable-maintainer-mode
+   make
+   sudo make install
+
+For later updates, you can use:
+
+.. code-block:: none
+
+   git pull
+   make
+   sudo make install
+
+SSL/TLS Support
+^^^^^^^^^^^^^^^
+
+OpenSSL is used by default, and it should be automatically detected.
+If it is not, you are missing some header files or libraries, or they
+are just in a non-standard path. Make sure you have the ``openssl-dev``
+or a similar package installed, and if it is not in the standard
+location, set ``CPPFLAGS`` and ``LDFLAGS`` as shown in the first
+section above:
+
+.. code-block:: none
+
+   CPPFLAGS="-I/opt/openssl/include" LDFLAGS="-L/opt/openssl/lib" ./configure
+
+By default the SSL certificate is read from
+``/etc/ssl/certs/dovecot.pem`` and the private key from
+``/etc/ssl/private/dovecot.pem``. The ``/etc/ssl`` directory can be
+changed using the ``--with-ssldir=DIR`` configure option. Both can of
+course be overridden from the configuration file.
+
+Optional Configure Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dovecot is highly configurable when building from source. Optional packages can
+be included by providing options in the form of ``--with-something`` or
+``--enable-something``. Conversely ``--without-something`` or
+``--disable-something`` excludes the selected options. For an up-to-date list
+of available options - especially Optional Packages - run:
+
+.. code-block:: none
+
+   ./configure --help
+
+There are many default options that come from autoconf, automake or libtool.
+They are explained elsewhere.


### PR DESCRIPTION
This PR imports missing pages from the obsolete wiki, that are still referenced in the dovecot core project.

These pages were imported/converted from the wiki and afterwards manually updated, so that the links and contained information are up-to-date (as best as I could).

Closes DOV-5043