### PR TITLE
2.3 CHERRY-PICK: admin_manual/lua: Fix rst syntax

### DIFF
--- a/source/admin_manual/lua.rst
+++ b/source/admin_manual/lua.rst
@@ -32,12 +32,12 @@ return non-zero to indicate that the script has a problem.
 C API
 ^^^^^^
 
-.. c:function:: void dlua_dovecot_register(struct dlua_script \*script)
+.. c:function:: void dlua_dovecot_register(struct dlua_script *script)
 
 Register dovecot variable. This item can also be extended by context specific
 tables, like authentication database adds dovecot.auth.
 
-.. c:function:: void dlua_push_event(struct event \*event)
+.. c:function:: void dlua_push_event(struct event *event)
 
 Pushes an Dovecot Event to stack.
 


### PR DESCRIPTION
Broken in 55e20b7ec58a9be4bccc0931c9af2f5d066def5e