### PR TITLE
Dov-4458: Clarify supported mailbox formats

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -944,6 +944,7 @@ preinit
 PREREQ
 printf
 printfa
+prioritization
 Proactively
 procmail
 procmailrc

--- a/source/admin_manual/mailbox_formats.rst
+++ b/source/admin_manual/mailbox_formats.rst
@@ -6,41 +6,41 @@ Mailbox Formats
 
 Mailbox formats supported by Dovecot:
 
-+------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
-| Name                   | Tag         | Description                           | Supported in :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` |
-+========================+=============+=======================================+==============================================================+
-| :ref:`obox             | ``obox``    | OX Dovecot Pro object storage mailbox | ✅ yes                                                       |
-| <obox_settings>`       |             | format. (Pro only)                    |                                                              |
-+------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
-| :ref:`mbox             | ``mbox``    | Traditional UNIX mailbox format.      | ❌ no                                                        |
-| <mbox_mbox_format>`    |             | Users' INBOX mailboxes are commonly   |                                                              |
-|                        |             | stored in ``/var/spool/mail`` or      |                                                              |
-|                        |             | ``/var/mail`` directory. Single file  |                                                              |
-|                        |             | contains multiple messages.           |                                                              |
-+------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
-| :ref:`Maildir          | ``maildir`` | One file contains one message. A      | ❌ no                                                        |
-| <maildir_mbox_format>` |             | reliable choice since files are never |                                                              |
-|                        |             | modified and all operations are       |                                                              |
-|                        |             | atomic. The top-level Maildir         |                                                              |
-|                        |             | directory contains the                |                                                              |
-|                        |             | ``Maildir/cur``, ``Maildir/new``, and |                                                              |
-|                        |             | ``Maildir/tmp`` subdirectories.       |                                                              |
-+------------------------+-------------+------------------+--------------------+--------------------------------------------------------------+
-| :ref:`dbox             | ``sdbox``   | **single-dbox**, | Dovecot's own high | ✅ yes                                                       |
-| <dbox_mbox_format>`    |             | one message per  | performance        |                                                              |
-|                        |             | file.            | mailbox format.    |                                                              |
-|                        +-------------+------------------+ Messages are       +--------------------------------------------------------------+
-|                        | ``mdbox``   | **multi-dbox**,  | stored in one or   | ✅ yes                                                       |
-|                        |             | multiple         | more files, each   |                                                              |
-|                        |             | messages per     | containing one or  |                                                              |
-|                        |             | file.            | more messages.     |                                                              |
-+------------------------+-------------+------------------+--------------------+--------------------------------------------------------------+
-| :ref:`imapc            | ``imapc``   | Use remote IMAP server as mail        | ✅ yes                                                       |
-| <imapc_mbox_format>`   |             | storage.                              |                                                              |
-+------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
-| :ref:`pop3c            | ``pop3c``   | Use remote POP3 server as mail        | ❌ no                                                        |
-| <pop3c_mbox_format>`   |             | storage.                              |                                                              |
-+------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
++------------------------+-------------+---------------------------------------+------------------------------------+
+| Name                   | Tag         | Description                           | Supported in :ref:`ox_dovecot_pro` |
++========================+=============+=======================================+====================================+
+| :ref:`obox             | ``obox``    | OX Dovecot Pro object storage mailbox | ✅ yes                             |
+| <obox_settings>`       |             | format. (Pro only)                    |                                    |
++------------------------+-------------+---------------------------------------+------------------------------------+
+| :ref:`mbox             | ``mbox``    | Traditional UNIX mailbox format.      | ❌ no                              |
+| <mbox_mbox_format>`    |             | Users' INBOX mailboxes are commonly   |                                    |
+|                        |             | stored in ``/var/spool/mail`` or      |                                    |
+|                        |             | ``/var/mail`` directory. Single file  |                                    |
+|                        |             | contains multiple messages.           |                                    |
++------------------------+-------------+---------------------------------------+------------------------------------+
+| :ref:`Maildir          | ``maildir`` | One file contains one message. A      | ❌ no                              |
+| <maildir_mbox_format>` |             | reliable choice since files are never |                                    |
+|                        |             | modified and all operations are       |                                    |
+|                        |             | atomic. The top-level Maildir         |                                    |
+|                        |             | directory contains the                |                                    |
+|                        |             | ``Maildir/cur``, ``Maildir/new``, and |                                    |
+|                        |             | ``Maildir/tmp`` subdirectories.       |                                    |
++------------------------+-------------+------------------+--------------------+------------------------------------+
+| :ref:`dbox             | ``sdbox``   | **single-dbox**, | Dovecot's own high | ✅ yes                             |
+| <dbox_mbox_format>`    |             | one message per  | performance        |                                    |
+|                        |             | file.            | mailbox format.    |                                    |
+|                        +-------------+------------------+ Messages are       +------------------------------------+
+|                        | ``mdbox``   | **multi-dbox**,  | stored in one or   | ✅ yes                             |
+|                        |             | multiple         | more files, each   |                                    |
+|                        |             | messages per     | containing one or  |                                    |
+|                        |             | file.            | more messages.     |                                    |
++------------------------+-------------+------------------+--------------------+------------------------------------+
+| :ref:`imapc            | ``imapc``   | Use remote IMAP server as mail        | ✅ yes                             |
+| <imapc_mbox_format>`   |             | storage.                              |                                    |
++------------------------+-------------+---------------------------------------+------------------------------------+
+| :ref:`pop3c            | ``pop3c``   | Use remote POP3 server as mail        | ❌ no                              |
+| <pop3c_mbox_format>`   |             | storage.                              |                                    |
++------------------------+-------------+---------------------------------------+------------------------------------+
 
 The Tag column indicates the tag which is used at the beginning of a
 :ref:`mailbox location specification <mail_location_settings>`.
@@ -111,9 +111,8 @@ Shared Storage
 
 The recommended storage solution for large installations that require
 high-availability and scalable performance is object storage.
-:ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` provides the
-:ref:`obox mailbox format <obox_settings>` to efficiently interact with
-selected object storage systems.
+:ref:`ox_dovecot_pro` provides the :ref:`obox mailbox format <obox_settings>`
+to efficiently interact with selected object storage systems.
 
 Dovecot allows keeping mails and index files in clustered filesystems.
 Dovecot does not specifically support any specific clustered solution - it

--- a/source/admin_manual/mailbox_formats.rst
+++ b/source/admin_manual/mailbox_formats.rst
@@ -6,41 +6,41 @@ Mailbox Formats
 
 Mailbox formats supported by Dovecot:
 
-+------------------------+-------------+---------------------------------------+
-| Name                   | Tag         | Description                           |
-+========================+=============+=======================================+
-| :ref:`obox             | ``obox``    | OX Dovecot Pro object storage mailbox |
-| <obox_settings>`       |             | format. (Pro only)                    |
-+------------------------+-------------+---------------------------------------+
-| :ref:`mbox             | ``mbox``    | Traditional UNIX mailbox format.      |
-| <mbox_mbox_format>`    |             | Users' INBOX mailboxes are commonly   |
-|                        |             | stored in ``/var/spool/mail`` or      |
-|                        |             | ``/var/mail`` directory. Single file  |
-|                        |             | contains multiple messages.           |
-+------------------------+-------------+---------------------------------------+
-| :ref:`Maildir          | ``maildir`` | One file contains one message. A      |
-| <maildir_mbox_format>` |             | reliable choice since files are never |
-|                        |             | modified and all operations are       |
-|                        |             | atomic. The top-level Maildir         |
-|                        |             | directory contains the                |
-|                        |             | ``Maildir/cur``, ``Maildir/new``, and |
-|                        |             | ``Maildir/tmp`` subdirectories.       |
-+------------------------+-------------+------------------+--------------------+
-| :ref:`dbox             | ``sdbox``   | **single-dbox**, | Dovecot's own high |
-| <dbox_mbox_format>`    |             | one message per  | performance        |
-|                        |             | file.            | mailbox format.    |
-|                        +-------------+------------------+ Messages are       |
-|                        | ``mdbox``   | **multi-dbox**,  | stored in one or   |
-|                        |             | multiple         | more files, each   |
-|                        |             | messages per     | containing one or  |
-|                        |             | file.            | more messages.     |
-+------------------------+-------------+------------------+--------------------+
-| :ref:`imapc            | ``imapc``   | Use remote IMAP server as mail        |
-| <imapc_mbox_format>`   |             | storage.                              |
-+------------------------+-------------+---------------------------------------+
-| :ref:`pop3c            | ``pop3c``   | Use remote POP3 server as mail        |
-| <pop3c_mbox_format>`   |             | storage.                              |
-+------------------------+-------------+---------------------------------------+
++------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
+| Name                   | Tag         | Description                           | Supported in :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` |
++========================+=============+=======================================+==============================================================+
+| :ref:`obox             | ``obox``    | OX Dovecot Pro object storage mailbox | ✅ yes                                                       |
+| <obox_settings>`       |             | format. (Pro only)                    |                                                              |
++------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
+| :ref:`mbox             | ``mbox``    | Traditional UNIX mailbox format.      | ❌ no                                                        |
+| <mbox_mbox_format>`    |             | Users' INBOX mailboxes are commonly   |                                                              |
+|                        |             | stored in ``/var/spool/mail`` or      |                                                              |
+|                        |             | ``/var/mail`` directory. Single file  |                                                              |
+|                        |             | contains multiple messages.           |                                                              |
++------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
+| :ref:`Maildir          | ``maildir`` | One file contains one message. A      | ❌ no                                                        |
+| <maildir_mbox_format>` |             | reliable choice since files are never |                                                              |
+|                        |             | modified and all operations are       |                                                              |
+|                        |             | atomic. The top-level Maildir         |                                                              |
+|                        |             | directory contains the                |                                                              |
+|                        |             | ``Maildir/cur``, ``Maildir/new``, and |                                                              |
+|                        |             | ``Maildir/tmp`` subdirectories.       |                                                              |
++------------------------+-------------+------------------+--------------------+--------------------------------------------------------------+
+| :ref:`dbox             | ``sdbox``   | **single-dbox**, | Dovecot's own high | ✅ yes                                                       |
+| <dbox_mbox_format>`    |             | one message per  | performance        |                                                              |
+|                        |             | file.            | mailbox format.    |                                                              |
+|                        +-------------+------------------+ Messages are       +--------------------------------------------------------------+
+|                        | ``mdbox``   | **multi-dbox**,  | stored in one or   | ✅ yes                                                       |
+|                        |             | multiple         | more files, each   |                                                              |
+|                        |             | messages per     | containing one or  |                                                              |
+|                        |             | file.            | more messages.     |                                                              |
++------------------------+-------------+------------------+--------------------+--------------------------------------------------------------+
+| :ref:`imapc            | ``imapc``   | Use remote IMAP server as mail        | ✅ yes                                                       |
+| <imapc_mbox_format>`   |             | storage.                              |                                                              |
++------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
+| :ref:`pop3c            | ``pop3c``   | Use remote POP3 server as mail        | ❌ no                                                        |
+| <pop3c_mbox_format>`   |             | storage.                              |                                                              |
++------------------------+-------------+---------------------------------------+--------------------------------------------------------------+
 
 The Tag column indicates the tag which is used at the beginning of a
 :ref:`mailbox location specification <mail_location_settings>`.

--- a/source/admin_manual/mailbox_formats/dbox.rst
+++ b/source/admin_manual/mailbox_formats/dbox.rst
@@ -11,6 +11,11 @@ redesigned in v1.1 series and improved even further in v2.0.
 For information on how to configure dbox in Dovecot, see
 :ref:`dbox_settings`.
 
+.. Note::
+
+   This mailbox format is officially supported by :ref:`OX Dovecot Pro
+   <ox_dovecot_pro_releases>`.
+
 Usage
 ^^^^^
 

--- a/source/admin_manual/mailbox_formats/dbox.rst
+++ b/source/admin_manual/mailbox_formats/dbox.rst
@@ -13,8 +13,7 @@ For information on how to configure dbox in Dovecot, see
 
 .. Note::
 
-   This mailbox format is officially supported by :ref:`OX Dovecot Pro
-   <ox_dovecot_pro_releases>`.
+   This mailbox format is officially supported by :ref:`ox_dovecot_pro`.
 
 Usage
 ^^^^^

--- a/source/admin_manual/mailbox_formats/maildir.rst
+++ b/source/admin_manual/mailbox_formats/maildir.rst
@@ -13,6 +13,15 @@ networked file systems such as NFS.
 For information on how to configure Maildir in Dovecot, see
 :ref:`maildir_settings`.
 
+.. Note::
+
+   The Maildir mailbox format is mainly viable for smaller installations.
+
+   It is not supported by :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` and
+   will be maintained on a best-effort basis for :ref:`Dovecot Community
+   Edition <dovecot_community_repositories>`, without any prioritization of new
+   features or optimizations.
+
 Dovecot Extensions
 ^^^^^^^^^^^^^^^^^^
 

--- a/source/admin_manual/mailbox_formats/maildir.rst
+++ b/source/admin_manual/mailbox_formats/maildir.rst
@@ -17,9 +17,9 @@ For information on how to configure Maildir in Dovecot, see
 
    The Maildir mailbox format is mainly viable for smaller installations.
 
-   It is not supported by :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` and
-   will be maintained on a best-effort basis for :ref:`Dovecot Community
-   Edition <dovecot_community_repositories>`, without any prioritization of new
+   It is not supported by :ref:`ox_dovecot_pro` and will be maintained on a
+   best-effort basis for :ref:`Dovecot Community Edition
+   <dovecot_community_repositories>`, without any prioritization of new
    features or optimizations.
 
 Dovecot Extensions

--- a/source/admin_manual/mailbox_formats/maildir.rst
+++ b/source/admin_manual/mailbox_formats/maildir.rst
@@ -210,7 +210,7 @@ General Comparisons of Maildir on Different Filesystems
 * https://www.thesmbexchange.com/eng/qmail_fs_benchmark.html
 * https://www.htiweb.inf.br/benchmark/fsbench.htm (including some graphs)
 
-Linux ext2 / ext3 
+Linux ext2 / ext3
 -----------------
 
 The main disadvantage in using these filesystems is that searching can be

--- a/source/admin_manual/mailbox_formats/pop3c.rst
+++ b/source/admin_manual/mailbox_formats/pop3c.rst
@@ -14,5 +14,4 @@ For information on how to configure pop3c in Dovecot, see
 
 .. Note::
 
-   This mailbox format is not supported by :ref:`OX Dovecot Pro
-   <ox_dovecot_pro_releases>`.
+   This mailbox format is not supported by :ref:`ox_dovecot_pro`.

--- a/source/admin_manual/mailbox_formats/pop3c.rst
+++ b/source/admin_manual/mailbox_formats/pop3c.rst
@@ -11,3 +11,8 @@ The remote POP3 mailbox is visible as the INBOX folder on the Dovecot side.
 
 For information on how to configure pop3c in Dovecot, see
 :ref:`pop3c_settings`.
+
+.. Note::
+
+   This mailbox format is not supported by :ref:`OX Dovecot Pro
+   <ox_dovecot_pro_releases>`.

--- a/source/configuration_manual/fts/dovecot.rst
+++ b/source/configuration_manual/fts/dovecot.rst
@@ -4,7 +4,7 @@ Dovecot Pro FTS Engine
 ======================
 
 .. important:: The Dovecot Pro FTS driver is a part of
-               :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` only.
+               :ref:`ox_dovecot_pro` only.
 
 The Dovecot FTS indexes are created and queried by a custom (Dovecot Pro) FTS
 engine. The FTS engine component is loaded into the Dovecot FTS plugin as an

--- a/source/configuration_manual/fts/index.rst
+++ b/source/configuration_manual/fts/index.rst
@@ -39,7 +39,7 @@ Name                           Description
 ============================= ================================================
 :ref:`fts_backend_dovecot`    Dovecot native, object storage optimized driver.
                               Only available as part of
-                              :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>`.
+                              :ref:`ox_dovecot_pro`.
 :ref:`fts_backend_solr`       Interface to
                               `Apache Solr <https://solr.apache.org/>`_.
 :ref:`fts_backend_flatcurve`  `Xapian`_ based driver; stores data locally.
@@ -124,8 +124,7 @@ OX Dovecot Pro Full Text Search Backend
 ---------------------------------------
 
 :ref:`fts_backend_dovecot` is a proprietary FTS plugin available for
-:ref:`OX Dovecot Pro <ox_dovecot_pro_releases>`. It provides fast and compact
-indexing of search data.
+:ref:`ox_dovecot_pro`. It provides fast and compact indexing of search data.
 
 All Dovecot indexes, including FTS indexes, are stored in the same storage
 (including object storage) used to store the mail and index data. No

--- a/source/configuration_manual/mail_location/obox/dictmap.rst
+++ b/source/configuration_manual/mail_location/obox/dictmap.rst
@@ -9,8 +9,8 @@ internal "lib-fs paths" into dict API. The dict API paths in turn are
 translated to SQL/CQL queries via dict-sql.
 
 Cassandra requires installing dovecot-ee-cassandra-plugin package and the
-cpp-driver from 3rdparty repository. See :ref:`ox_dovecot_pro_releases`
-for further details.
+cpp-driver from 3rdparty repository. See :ref:`ox_dovecot_pro` for further
+details.
 
 The fs-dictmap syntax is:
 

--- a/source/configuration_manual/mail_location/obox/index.rst
+++ b/source/configuration_manual/mail_location/obox/index.rst
@@ -8,8 +8,7 @@ Obox Settings
 
    These settings are assuming that message data is being stored in object storage (obox mailbox). These settings should not be used if a block storage driver (e.g. mdbox) is being used.
 
-   This mailbox format is officially supported by :ref:`OX Dovecot Pro
-   <ox_dovecot_pro_releases>`.
+   This mailbox format is officially supported by :ref:`ox_dovecot_pro`.
 
 obox drivers
 ------------

--- a/source/configuration_manual/mail_location/obox/index.rst
+++ b/source/configuration_manual/mail_location/obox/index.rst
@@ -8,6 +8,9 @@ Obox Settings
 
    These settings are assuming that message data is being stored in object storage (obox mailbox). These settings should not be used if a block storage driver (e.g. mdbox) is being used. 
 
+   This mailbox format is officially supported by :ref:`OX Dovecot Pro
+   <ox_dovecot_pro_releases>`.
+
 obox drivers
 ------------
 

--- a/source/configuration_manual/mail_location/obox/index.rst
+++ b/source/configuration_manual/mail_location/obox/index.rst
@@ -6,7 +6,7 @@ Obox Settings
 
 .. Note:: 
 
-   These settings are assuming that message data is being stored in object storage (obox mailbox). These settings should not be used if a block storage driver (e.g. mdbox) is being used. 
+   These settings are assuming that message data is being stored in object storage (obox mailbox). These settings should not be used if a block storage driver (e.g. mdbox) is being used.
 
    This mailbox format is officially supported by :ref:`OX Dovecot Pro
    <ox_dovecot_pro_releases>`.
@@ -124,26 +124,26 @@ Core settings
 
    mail_home = /var/vmail/%2Mu/%u
 
-Specifies the location for the local mail cache directory. This will contain Dovecot index files and it needs to be high performance (e.g. SSD storage). Alternatively, if there is enough memory available to hold all concurrent users' data at once, a tmpfs would work as well. The "%2Mu" takes the first 2 chars of the MD5 hash of the username so everything isn't in one directory. 
+Specifies the location for the local mail cache directory. This will contain Dovecot index files and it needs to be high performance (e.g. SSD storage). Alternatively, if there is enough memory available to hold all concurrent users' data at once, a tmpfs would work as well. The "%2Mu" takes the first 2 chars of the MD5 hash of the username so everything isn't in one directory.
 
 .. code-block:: none
 
    mail_uid = vmail
    mail_gid = vmail
 
-UNIX UID & GID which are used to access the local cache mail files. 
+UNIX UID & GID which are used to access the local cache mail files.
 
 .. code-block:: none
 
    mail_fsync = never
 
-We can disable fsync()ing for better performance. It's not a problem if locally cached index file modifications are lost. 
+We can disable fsync()ing for better performance. It's not a problem if locally cached index file modifications are lost.
 
 .. code-block:: none
 
    mail_temp_dir = /tmp
 
-Directory where downloaded/uploaded mails are temporarily stored to. Ideally all of these would stay in memory and never hit the disk, but in some situations the mails may have to be kept for a somewhat longer time and it ends up in disk. So there should be enough disk space available in the temporary filesystem. 
+Directory where downloaded/uploaded mails are temporarily stored to. Ideally all of these would stay in memory and never hit the disk, but in some situations the mails may have to be kept for a somewhat longer time and it ends up in disk. So there should be enough disk space available in the temporary filesystem.
 
 .. NOTE::
 

--- a/source/configuration_manual/quota/unified_quota_configuration.rst
+++ b/source/configuration_manual/quota/unified_quota_configuration.rst
@@ -4,8 +4,7 @@
 Unified Quota Configuration
 ===========================
 
-Unified quota is only available as part of
-:ref:`OX Dovecot Pro <ox_dovecot_pro_releases>`.
+Unified quota is only available as part of :ref:`ox_dovecot_pro`.
 
 Unified quota plugin is a combined count and dict plugin, which uses
 quota:count to keep tabs of local quota and dict lookups to maintain external

--- a/source/installation_guide/dovecot_pro_releases/index.rst
+++ b/source/installation_guide/dovecot_pro_releases/index.rst
@@ -1,8 +1,8 @@
-.. _ox_dovecot_pro_releases:
+.. _ox_dovecot_pro:
   
-#######################
-OX Dovecot Pro Releases
-#######################
+##############
+OX Dovecot Pro
+##############
 
 `OX Dovecot Pro <https://www.open-xchange.com/portfolio/ox-dovecot-pro/>`_ is
 a commercial software product of

--- a/source/installation_guide/dovecot_pro_releases/repository_guide.rst
+++ b/source/installation_guide/dovecot_pro_releases/repository_guide.rst
@@ -27,7 +27,7 @@ OX Dovecot Pro v2.3
 -------------------
 
 Repository details can be found in release specific documentation in
-:ref:`ox_dovecot_pro_releases`.
+:ref:`ox_dovecot_pro`.
 
 OX Dovecot Pro v2.2 (EOL)
 -------------------------

--- a/source/settings/plugin/fts-dovecot-plugin.rst
+++ b/source/settings/plugin/fts-dovecot-plugin.rst
@@ -4,8 +4,7 @@
 fts-dovecot plugin
 ==================
 
-.. important:: The Dovecot FTS driver is a part of
-               :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` only.
+.. important:: The Dovecot FTS driver is a part of :ref:`ox_dovecot_pro` only.
 
 .. seealso:: See :ref:`fts_backend_dovecot` for detailed information.
 

--- a/source/settings/plugin/fts-plugin.rst
+++ b/source/settings/plugin/fts-plugin.rst
@@ -507,7 +507,7 @@ Settings
    ``kuromoji``
 
      .. important:: The kuromoji tokenizer is a part of
-                    :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>` only.
+                    :ref:`ox_dovecot_pro` only.
 
      This tokenizer is used for Japanese text. This tokenizer
      utilizes Atilika Kuromoji tokenizer library to tokenize Japanese text.

--- a/source/settings/plugin/pop3-uidl-migrate-plugin.rst
+++ b/source/settings/plugin/pop3-uidl-migrate-plugin.rst
@@ -5,7 +5,7 @@ pop3-uidl-migrate plugin
 ========================
 
 .. note:: pop3-uidl-migrate plugin is only available as part of
-  :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>`.
+  :ref:`ox_dovecot_pro`.
 
 Settings
 ========

--- a/source/settings/plugin/vault-plugin.rst
+++ b/source/settings/plugin/vault-plugin.rst
@@ -6,8 +6,7 @@ vault Plugin
 
 .. note::
 
-  Vault plugin is only available as part of
-  :ref:`OX Dovecot Pro <ox_dovecot_pro_releases>`.
+  Vault plugin is only available as part of :ref:`ox_dovecot_pro`.
 
 The vault plugin performs the job of storing the incoming mail first to
 a configurable mailbox location (e.g. ``ARCHIVE``) and, if that succeeds,


### PR DESCRIPTION
This PR specifies which mailbox format is supported by Dovecot Pro. Once for each individual page, as well as in the main overview table.

I also took the liberty to remove stray whitespaces in files I touched anyways.

Closes DOV-4458 