### PR TITLE
DOV-5009 - update compression documentation

### DIFF
--- a/source/configuration_manual/mail_location/obox/amazon_s3.rst
+++ b/source/configuration_manual/mail_location/obox/amazon_s3.rst
@@ -176,9 +176,9 @@ With IAM:
 
    mail_location = obox:%8Mu/%u:INDEX=~/:CONTROL=~/
    plugin {
-     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:gz:6:aws-s3:https://dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
-     obox_index_fs = compress:gz:6:aws-s3:https://dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
-     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:gz:6:aws-s3:https://dovecot-mails.s3.eu-central-1.amazonaws.com/%8Mu/%u/fts/?region=eu-central-1&auth_role=s3access
+     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:zstd:3:aws-s3:https://dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
+     obox_index_fs = compress:zstd:3:aws-s3:https://dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
+     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:zstd:3:aws-s3:https://dovecot-mails.s3.eu-central-1.amazonaws.com/%8Mu/%u/fts/?region=eu-central-1&auth_role=s3access
      obox_max_parallel_deletes = 1000
    }
    mail_uid = vmail
@@ -194,8 +194,8 @@ Without IAM:
 
    mail_location = obox:%8Mu/%u:INDEX=~/:CONTROL=~/
    plugin {
-     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:gz:6:aws-s3:https://ACCESSKEY:SECRET@dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
-     obox_index_fs = compress:gz:6:aws-s3:https://ACCESSKEY:SECRET@dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
-     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:gz:6:aws-s3:https://ACCESSKEY:SECRET@dovecot-mails.s3.eu-central-1.amazonaws.com/%8Mu/%u/fts/?region=eu-central-1&auth_role=s3access
+     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:zstd:3:aws-s3:https://ACCESSKEY:SECRET@dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
+     obox_index_fs = compress:zstd:3:aws-s3:https://ACCESSKEY:SECRET@dovecot-mails.s3.eu-central-1.amazonaws.com/?region=eu-central-1&auth_role=s3access
+     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:zstd:3:aws-s3:https://ACCESSKEY:SECRET@dovecot-mails.s3.eu-central-1.amazonaws.com/%8Mu/%u/fts/?region=eu-central-1&auth_role=s3access
      obox_max_parallel_deletes = 1000
    }

--- a/source/configuration_manual/mail_location/obox/dictmap.rst
+++ b/source/configuration_manual/mail_location/obox/dictmap.rst
@@ -40,8 +40,8 @@ Cassandra/sproxyd Example Configuration
      # With lazy_expunge plugin:
      #obox_fs = fscache:512M:/var/cache/mails/%4Nu:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; refcounting-table:bucket-size=10000:bucket-cache=%h/buckets.cache:nlinks-limit=3:delete-timestamp=+10s:bucket-deleted-days=11
 
-     obox_index_fs = compress:gz:6:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; diff-table
-     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:gz:6:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=1&reason_header_max_length=200 ; dict-prefix=%u/fts/
+     obox_index_fs = compress:zstd:3:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; diff-table
+     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:zstd:3:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=1&reason_header_max_length=200 ; dict-prefix=%u/fts/
    }
 
 It's highly recommended to use :ref:`lazy_expunge_plugin` with dictmap.

--- a/source/configuration_manual/mail_location/obox/s3.rst
+++ b/source/configuration_manual/mail_location/obox/s3.rst
@@ -63,9 +63,9 @@ AWS S3 specific example configurations.
 
    mail_location = obox:%8Mu/%u:INDEX=~/:CONTROL=~/
    plugin {
-     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:gz:6:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
-     obox_index_fs = compress:gz:6:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
-     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:gz:6:s3:https://s3.example.com/%8Mu/%u/fts/?bucket=mails
+     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:zstd:3:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
+     obox_index_fs = compress:zstd:3:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
+     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:zstd:3:s3:https://s3.example.com/%8Mu/%u/fts/?bucket=mails
      obox_max_parallel_deletes = 1000
    }
 

--- a/source/configuration_manual/mail_location/obox/scality_cdmi.rst
+++ b/source/configuration_manual/mail_location/obox/scality_cdmi.rst
@@ -53,9 +53,9 @@ Example configuration
 
    mail_location = obox:%2Mu/%2.3Mu/%u:INDEX=~/:CONTROL=~/
    plugin {
-     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:gz:6:scality:http://scality.example.com/?addhdr=X-Dovecot-Hash:%2Mu/%2.3Mu&use_listing&timeout_msecs=65000
-     obox_index_fs = compress:gz:6:scality:http://scality.example.com/?addhdr=X-Dovecot-Hash:%2Mu/%2.3Mu&use_listing&timeout_msecs=65000
-     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:gz:6:scality:http://scality.example.com/%2Mu/%2.3Mu/%u/fts/?addhdr=X-Dovecot-Hash:%2Mu/%2.3Mu&use_listing&timeout_msecs=65000
+     obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:zstd:3:scality:http://scality.example.com/?addhdr=X-Dovecot-Hash:%2Mu/%2.3Mu&use_listing&timeout_msecs=65000
+     obox_index_fs = compress:zstd:3:scality:http://scality.example.com/?addhdr=X-Dovecot-Hash:%2Mu/%2.3Mu&use_listing&timeout_msecs=65000
+     fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:zstd:3:scality:http://scality.example.com/%2Mu/%2.3Mu/%u/fts/?addhdr=X-Dovecot-Hash:%2Mu/%2.3Mu&use_listing&timeout_msecs=65000
 
      # With bulk-delete and bulk-link enabled, parallel operations can be large.
      # They should not be larger than bulk_delete_limit and bulk_link_limit.

--- a/source/configuration_manual/plugins/fs-compress-plugin.rst
+++ b/source/configuration_manual/plugins/fs-compress-plugin.rst
@@ -50,9 +50,9 @@ For example:
 
 .. code-block:: none
 
-   obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:maybe-gz:6:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
+   obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:maybe-zstd:3:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
 
-This decompresses mails if they were stored using gz compression and falls
+This decompresses mails if they were stored using zstd compression and falls
 back to reading the mails as plaintext.
 
 .. warning:: Prior to v2.3.13 it is not possible to use multiple different
@@ -63,19 +63,19 @@ Example Configuration
 
 .. code-block:: none
 
-  obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:gz:6:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
-  fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:gz:6:s3:https://s3.example.com/%8Mu/%u/fts/?bucket=mails
+  obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:zstd:3:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
+  fts_dovecot_fs = fts-cache:fscache:512M:/var/cache/fts/%4Nu:compress:zstd:3:s3:https://s3.example.com/%8Mu/%u/fts/?bucket=mails
 
 Note that these both work and don't have any practical difference, because
 fs-dictmap doesn't modify the object contents in any way:
 
 .. code-block:: none
 
-  obox_index_fs = compress:gz:6:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; diff-table
-  obox_index_fs = dictmap:proxy:dict-async:cassandra ; compress:gz:6:sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; diff-table
+  obox_index_fs = compress:zstd:3:dictmap:proxy:dict-async:cassandra ; sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; diff-table
+  obox_index_fs = dictmap:proxy:dict-async:cassandra ; compress:zstd:3:sproxyd:http://sproxyd.scality.example.com/?class=2&reason_header_max_length=200 ; diff-table
 
 With encryption enabled:
 
 .. code-block:: none
 
-  obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:gz:6:mail-crypt:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails
+  obox_fs = fscache:512M:/var/cache/mails/%4Nu:compress:zstd:3:mail-crypt:s3:https://ACCESSKEY:SECRET@s3.example.com/?bucket=mails

--- a/source/configuration_manual/zlib_plugin.rst
+++ b/source/configuration_manual/zlib_plugin.rst
@@ -24,8 +24,8 @@ Sample Configuration:
 
   # Enable these only if you want compression while saving:
   plugin {
-    zlib_save = gz
-    zlib_save_level = 6
+    zlib_save = zstd
+    zlib_save_level = 3
   }
 
 Interaction with Mailbox Formats

--- a/source/settings/plugin/zlib-plugin.rst
+++ b/source/settings/plugin/zlib-plugin.rst
@@ -34,7 +34,7 @@ Settings
 
    .. code-block:: none
 
-      zlib_save = gz
+      zlib_save = zstd
 
 
 .. dovecot_plugin:setting:: zlib_save_level
@@ -60,7 +60,7 @@ Settings
 
    .. code-block:: none
 
-      zlib_save_level = 6
+      zlib_save_level = 3
 
    .. versionchanged:: v2.3.15
 


### PR DESCRIPTION
Replace `gz` with `zstd` in compression algorithm documentation:
- Main examples of `zlib_save`/`zlib_save_level`, and
- fs-compress example usages.

Closes DOV-5009