### PR TITLE
DOV-5266 - Document migration from Global ACL Directories to Files

### DIFF
--- a/source/configuration_manual/acl.rst
+++ b/source/configuration_manual/acl.rst
@@ -129,6 +129,9 @@ file overrides per-mailbox ACL file. This is because users can modify their own
 per-mailbox ACL files via IMAP ACL extension. Global ACLs can only be modified
 by administrator, so users shouldn't be able to override them.
 
+
+.. _acl-global_acl_file:
+
 Global ACL file
 ^^^^^^^^^^^^^^^
 

--- a/source/installation_guide/upgrading/from-2.3-to-3.0.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-3.0.rst
@@ -65,7 +65,7 @@ Removed features and their replacements
 | Weak password schemes                                      | Weak password schemes are disabled by default, you need to use                           |
 |                                                            | :dovecot_core:ref:`auth_allow_weak_schemes` to enable them.                              |
 +------------------------------------------------------------+------------------------------------------------------------------------------------------+
-| Global ACL directory                                       | Use global acl file instead.                                                             |
+| Global ACL directory                                       | Use :ref:`acl-global_acl_file` instead.                                                  |
 +------------------------------------------------------------+------------------------------------------------------------------------------------------+
 | ``ssl-parameters.dat``                                     | This file is no longer converted automatically by config process, you need to set        |
 |                                                            | :dovecot_core:ref:`ssl_dh` setting if you need non-ECC Diffie-Hellman.                   |


### PR DESCRIPTION
This PR adds a clarification section regarding migrating ACL directories to appropriate files, as the former has been deprecated and is going to be deleted starting with v3.0 going forward.

Closes DOV-5266