### PR TITLE
Update check-spelling

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -137,7 +137,6 @@ CApath
 cas
 Cazabon
 cbc
-ccs
 cdb
 cdmi
 certbot
@@ -274,7 +273,6 @@ DLLVM
 dlog
 dlua
 DMARC
-dnotify
 dnpass
 dns
 docidx
@@ -358,7 +356,6 @@ eokb
 eol
 eperm
 epk
-epoll
 epub
 EROFS
 errno
@@ -427,7 +424,6 @@ fstat
 fsuid
 fsync
 fsyncing
-ftp
 fts
 ftscache
 FULLDIRNAME
@@ -451,7 +447,6 @@ gethostbyname
 gethosterror
 gethostname
 getmail
-getmailbird
 getpid
 getpwnam
 GETQUOTA
@@ -485,11 +480,9 @@ hara
 hardcoded
 hardlink
 hardlinking
-hardlinks
 hasfrop
 hashmap
 hatv
-haxx
 hba
 hda
 HDD
@@ -507,7 +500,6 @@ homedir
 homepage
 hostaddr
 hostchange
-HOSTDOMAIN
 hostname
 Hotspot
 howto
@@ -562,7 +554,6 @@ ino
 inode
 inodetofile
 inotify
-inotifytools
 INTERNALDATE
 internalfail
 interoperable
@@ -613,7 +604,6 @@ kuromoji
 kuserok
 KVM
 LANMAN
-largefile
 lasthost
 lastlogin
 launchd
@@ -644,20 +634,15 @@ libexec
 libexpat
 libexttextcat
 libicu
-libkrb
-libldap
 liblib
 liblz
 liblzma
-libmysqlclient
 libpam
 libpq
 libsodium
-libsqlite
 libstemmer
 libtool
 libuv
-libwrap
 lifewithqmail
 linelen
 linenos
@@ -939,7 +924,6 @@ pidof
 Piljk
 pkcs
 pkey
-pkgconfig
 pki
 plaa
 plist
@@ -984,7 +968,6 @@ PROT
 proxyauth
 Ptest
 ptr
-ptrace
 pubout
 pukki
 PUTSCRIPT
@@ -1044,7 +1027,6 @@ rfc
 rhel
 RHu
 RLIMIT
-rml
 Rnotation
 Roboto
 roundcube
@@ -1112,7 +1094,6 @@ setra
 setrecursionlimit
 setsid
 SFTP
-sfw
 sgid
 SHAREDDIR
 sharedmail
@@ -1226,8 +1207,6 @@ Subtables
 subvalue
 sudo
 sudoers
-sunfreeware
-sunsite
 SUSE
 svbin
 swapoff
@@ -1304,7 +1283,6 @@ tostring
 transitioning
 trie
 Trojita
-Tru
 tscript
 ttl
 tukaani
@@ -1412,11 +1390,9 @@ vlast
 vmail
 vmback
 vmware
-VMware
 vname
 vnd
 VOLATILEDIR
-vpopmail
 vpv
 VRFY
 vsize
@@ -1424,7 +1400,6 @@ vsz
 wal
 wbytes
 wchar
-Wcry
 weakforced
 webmail
 webpage
@@ -1433,10 +1408,10 @@ wforce
 wget
 whitelisting
 Wietse
-WILLNEED
 wiki
 wikipedia
 wildcards
+WILLNEED
 winbind
 Wordlist
 workaround

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -11,8 +11,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: read
     outputs:
-      internal_state_directory: ${{ steps.spelling.outputs.internal_state_directory }}
+      followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
     if: "contains(github.event_name, 'pull_request') || github.event_name == 'push'"
     concurrency:
@@ -20,49 +21,25 @@ jobs:
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
-    - name: checkout-merge
-      if: "contains(github.event_name, 'pull_request')"
-      uses: check-spelling/checkout-merge@v0.0.0
     - name: check-spelling
-      if: env.MERGE_FAILED != '1'
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.20-alpha4
+      uses: check-spelling/check-spelling@prerelease
       with:
         suppress_push_for_open_pull_request: 1
+        checkout: true
         post_comment: 0
-    - name: store-comment
-      if: failure() && steps.spelling.outputs.internal_state_directory
-      uses: actions/upload-artifact@v2
-      with:
-        retention-days: 1
-        name: "check-spelling-comment-${{ github.run_id }}"
-        path: |
-          ${{ steps.spelling.outputs.internal_state_directory }}
 
   comment:
-    name: Comment
+    name: Report
     runs-on: ubuntu-latest
     needs: spelling
     permissions:
       contents: write
       pull-requests: write
-    if: always() && needs.spelling.result == 'failure' && needs.spelling.outputs.internal_state_directory
+    if: always() && needs.spelling.outputs.followup
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
-    - name: set up
-      run: |
-        mkdir /tmp/data
-    - name: retrieve-comment
-      uses: actions/download-artifact@v2
-      with:
-        name: "check-spelling-comment-${{ github.run_id }}"
-        path: /tmp/data
     - name: comment
-      uses: check-spelling/check-spelling@v0.0.20-alpha4
+      uses: check-spelling/check-spelling@v0.0.20-alpha7
       with:
-        experimental_apply_changes_via_bot: 1
-        custom_task: comment
-        internal_state_directory: /tmp/data
+        checkout: true
+        task: ${{ needs.spelling.outputs.followup }}


### PR DESCRIPTION
Using check-spelling/spell-check-this@prerelease
https://github.com/check-spelling/spell-check-this/commit/2726f866a529c3bab27c98c64e32bb6adcd13e9e

Changes:
- removes errant suggestion to talk to the bot
  It's possible to enable this feature, but it wasn't meant to be
  enabled as part of the initial deployment for this repository.
- simplify workflow
- update expect (removing stale entries)

Before:
https://github.com/jsoref/dovecot-documentation/runs/6546577392?check_suite_focus=true

After:
https://github.com/jsoref/dovecot-documentation/runs/6546574426?check_suite_focus=true

The main change is internalizing the checkout and artifact management (and associated message passing) details into the action itself.

In doing this, the artifact steps are upgrading from @v2 to @v3 (which is basically because the artifacts changed to using a newer version of the node runtime).

Basically the removed bits are moving here:
https://github.com/check-spelling/check-spelling/blob/v0.0.20-alpha7/action.yml#L220-L265