### PR TITLE
DOV-5284: Streamline compilation effort

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -457,6 +457,7 @@ GETSCRIPT
 gettext
 github
 gitlab
+glibc
 globals
 Gluster
 gmail
@@ -780,6 +781,7 @@ MULTIAPPEND
 multiline
 multiscript
 murchison
+musl
 mutf
 mybox
 mydomain
@@ -875,8 +877,10 @@ oldkey
 oldname
 oldstats
 onelevel
+onlinepubs
 opendir
 opendirectory
+opengroup
 openid
 openldap
 openmetrics
@@ -1211,6 +1215,7 @@ subvalue
 sudo
 sudoers
 SUSE
+sustainability
 svbin
 swapoff
 swappiness

--- a/source/installation_guide/dovecot_community_repositories/compiling_source.rst
+++ b/source/installation_guide/dovecot_community_repositories/compiling_source.rst
@@ -64,9 +64,6 @@ the following software/packages installed:
 
 -  ``gettext``
 
--  ``pandoc`` (not strictly required - you can avoid it by using:
-   ``PANDOC=false ./configure``)
-
 -  GNU make.
 
 It is advisable to add ``--enable-maintainer-mode`` to the ``configure``

--- a/source/installation_guide/dovecot_community_repositories/source_tarballs.rst
+++ b/source/installation_guide/dovecot_community_repositories/source_tarballs.rst
@@ -5,3 +5,6 @@ Source tarballs
 ===============
 
 You can find source tarballs under `download <https://www.dovecot.org/download.html>`_.
+
+See :ref:`_compiling_source` for a guide to build and install the software from
+the tarballs.

--- a/source/installation_guide/index.rst
+++ b/source/installation_guide/index.rst
@@ -12,3 +12,28 @@ Installation guide
    dovecot_community_repositories/index
    upgrading/index
    startup_scripts/index
+
+Target Platform
+^^^^^^^^^^^^^^^
+
+As part of improving maintainability and sustainability of the code this
+project defines a target platform specification and a minimum language standard
+beginning with version v2.4.0. As a platform specification the target is
+:ref:`POSIX.1-2008
+<https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/>`. The code
+requires a C99/C11 compatible compiler optimally with GNU extensions available.
+Currently glibc 2.17 is assumed to be the lowest supported C Standard library
+version, although others (e.g. older versions or musl) might work as well.
+
+For the following OS/distributions :ref:`ox_dovecot_pro` packages are
+automatically built:
+
+* CentOS 7
+* Debian 10 ("Buster")
+* Debian 11 ("Bullseye")
+* RHEL 8
+* Ubuntu 20
+* Amazon Linux 2
+
+Others - especially BSD derivatives (e.g. FreeBSD, OpenBSD, macOS, etc.) - are
+maintained on a best-effort base only.


### PR DESCRIPTION
Changes:
- Document decision/clarification about target platform, compiler and c standard,
- add link from source_tarballs to compile_sources, and
- remove requirement of pandoc in compile_sources.