### PR TITLE
Typo in number of RFC

### DIFF
--- a/source/configuration_manual/sieve/extensions/duplicate.rst
+++ b/source/configuration_manual/sieve/extensions/duplicate.rst
@@ -5,7 +5,7 @@ Pigeonhole Sieve: Duplicate Extension
 =====================================
 
 The **duplicate** extension `RFC
-7353 <http://tools.ietf.org/html/rfc7352>`_ adds a new test command
+7352 <http://tools.ietf.org/html/rfc7352>`_ adds a new test command
 called ``duplicate`` to the Sieve language. This test adds the ability
 to detect duplications. The main application for this new test is
 handling duplicate deliveries commonly caused by mailing list


### PR DESCRIPTION
There's a typo in the number of the RFC: it has to be 7352 (Sieve Email Filtering: Detecting Duplicate Deliveries) instead of 7353 (Security Requirements for BGP Path Validation). But the link to the IETF website is/was correct.