### PR TITLE
DOV-5437: Fix compilation links

### DIFF
--- a/source/installation_guide/dovecot_community_repositories/source_tarballs.rst
+++ b/source/installation_guide/dovecot_community_repositories/source_tarballs.rst
@@ -6,5 +6,5 @@ Source tarballs
 
 You can find source tarballs under `download <https://www.dovecot.org/download.html>`_.
 
-See :ref:`_compiling_source` for a guide to build and install the software from
+See :ref:`compiling_source` for a guide to build and install the software from
 the tarballs.

--- a/source/installation_guide/index.rst
+++ b/source/installation_guide/index.rst
@@ -19,7 +19,7 @@ Target Platform
 As part of improving maintainability and sustainability of the code this
 project defines a target platform specification and a minimum language standard
 beginning with version v2.4.0. As a platform specification the target is
-:ref:`POSIX.1-2008
+`POSIX.1-2008
 <https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/>`. The code
 requires a C99/C11 compatible compiler optimally with GNU extensions available.
 Currently glibc 2.17 is assumed to be the lowest supported C Standard library


### PR DESCRIPTION
- Fix internal link incorrectly pasted from anchor label (i.e. erroneously prefixed with `_`), and
- fix external link incorrectly prefixed with `:ref:`.

Closes DOV-5437.