### PR TITLE
check-spelling should use same version throughout

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -39,7 +39,7 @@ jobs:
     if: always() && needs.spelling.outputs.followup
     steps:
     - name: comment
-      uses: check-spelling/check-spelling@v0.0.20-alpha7
+      uses: check-spelling/check-spelling@prerelease
       with:
         checkout: true
         task: ${{ needs.spelling.outputs.followup }}


### PR DESCRIPTION
Missed this in:
a6560986d63d0eba36b8a99417de5c8f720858d1