### PR TITLE
DOV-5655: Rename `chronos` push notification plugin

### DIFF
--- a/source/configuration_manual/push_notification.rst
+++ b/source/configuration_manual/push_notification.rst
@@ -512,7 +512,12 @@ Transport-Independent Interoperability Protocol (iTIP)
 but can be used by any endpoint that implements the same API, not just OX App
 Suite.
 
-Configuration options:
+Configuration
+-------------
+
+The chronos push notification handler requires the
+``push_notification_chronos`` plugin to be loaded in addition to the plugins
+discussed :ref:`above <push_notification-usage>`.
 
 ================= ======== =================== ============================================================================================================
  Name             Required Type                Description
@@ -536,6 +541,8 @@ Configuration options:
 Example configuration:
 
 .. code-block:: none
+
+  mail_plugins = $mail_plugins notify push_notification push_notification_chronos
 
   plugin {
     push_notification_driver = chronos:url=http://login:pass@node1.domain.tld:8009/chronos/v1/itip/pushmail max_retries=2 timeout=2500ms msg_max_size=1mb

--- a/source/configuration_manual/push_notification.rst
+++ b/source/configuration_manual/push_notification.rst
@@ -545,7 +545,7 @@ Example configuration:
   mail_plugins = $mail_plugins notify push_notification push_notification_chronos
 
   plugin {
-    push_notification_driver = chronos:url=http://login:pass@node1.domain.tld:8009/chronos/v1/itip/pushmail max_retries=2 timeout=2500ms msg_max_size=1mb
+    push_notification_driver = chronos:url=http://login:pass@node1.domain.tld:8009/chronos/v1/itip/pushmail msg_max_size=1mb
   }
 
 Payload


### PR DESCRIPTION
For the sake of consistency the push notification plugin for the Chronos driver is to be made consistent with the other existing plugins (i.e. the lua push notification plugin in particular). This is done now, as no widespread distribution can be assumed.

This PR also includes a previous documentation PR, that updated the configuration description to be more consistent with the lua one. Specifically in terms of how to enable the plugin.

Closes DOV-5655.