### PR TITLE
DOV-5738: Document `imap_id_param` event

### DIFF
--- a/source/_ext/dovecot_sphinx.py
+++ b/source/_ext/dovecot_sphinx.py
@@ -502,9 +502,7 @@ class DovecotEventDirective(DovecotDirective):
             body += row
 
         """ Create collapsible container for event fields """
-        collapse = self._parse_rst(
-            ".. dropdown:: View Event Fields\n :animate: fade-in"
-        )
+        collapse = self._parse_rst(".. dropdown:: View Event Fields")
         collapse += table
         contentnode += collapse
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -35,7 +35,6 @@ Categories
 **********
 
 .. dropdown:: Root Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75
@@ -117,7 +116,6 @@ Categories
         - Submission process
 
 .. dropdown:: Storage Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75
@@ -145,7 +143,6 @@ Categories
         - pop3c storage
 
 .. dropdown:: Mailbox Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75
@@ -159,7 +156,6 @@ Categories
         - Mail
 
 .. dropdown:: Sieve Categories
-   :animate: fade-in
 
    .. versionadded:: v2.3.11 makes the ``sieve`` category parent for the other
                      ``sieve-*`` categories.
@@ -183,7 +179,6 @@ Categories
         - Sieve storage
 
 .. dropdown:: SQL Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -1113,6 +1113,28 @@ IMAP Command
    .. Note:: This event is currently not sent for pre-login IMAP commands.
 
 
+.. dovecot_core:event:: imap_id_received
+   :added: v2.4.0;v3.0.0
+   :inherit: imap_client
+
+   :field id_param_<param>: Received parameters. The event name is the lowercase
+                            parameter key prefixed with ``id_param_``, the value
+                            is the parameter value.
+   :field id_invalid<num>: Each key that contains invalid characters are
+                           enumerated starting with 1. Valid characters are
+                           latin alphabetic characters (= ``a`` .. ``z``),
+                           numerals (= ``0`` .. ``9``), the dash (= ``-``) and
+                           the underscore (= ``_``), every other character is
+                           considered invalid. The value of this field is the
+                           original parameter key including invalid characters,
+                           followed by a space character, and finally the
+                           original value concatenated into a single string.
+
+   This event is emitted when the IMAP ID command was received, both for pre-
+   as well as post-login. The parameters slightly differ for an unauthenticated
+   client, e.g. there is no user id.
+
+
 Mail Delivery
 =============
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -956,8 +956,11 @@ requests (e.g. doveadm HTTP API).
    the full response to the request has been sent to the client.
 
 
-POP3
-====
+..
+   Uncomment if there is an actual POP3 event.
+
+   POP3
+   ====
 
 .. dovecot_event:field_group:: pop3_client
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -20,14 +20,14 @@ Page options:
 
    <script>
    function toggleTables(expand) {
-     $('details.dropdown').each(function() {
+     $('details.sd-dropdown').each(function() {
        $(this).attr('open', expand);
      });
    }
    </script>
 
-   <button type="button" class="btn btn-primary" onclick="toggleTables(true)">Expand All Tables</button>
-   <button type="button" class="btn btn-secondary" onclick="toggleTables(false)">Collapse All Tables</button>
+   <button type="button" class="sd-btn sd-btn-secondary" onclick="toggleTables(true)">Expand All Tables</button>
+   <button type="button" class="sd-btn sd-btn-secondary" onclick="toggleTables(false)">Collapse All Tables</button>
 
 
 **********

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -1008,9 +1008,9 @@ IMAP Client
    :field user: Username of the user.
    :field session: Session ID of the IMAP connection.
    :field local_ip @added;v2.3.9: IMAP connection's local (server) IP.
-   :field local_part @added;v2.3.9: IMAP connection's local (server) port.
+   :field local_port @added;v2.3.9: IMAP connection's local (server) port.
    :field remote_ip @added;v2.3.9: IMAP connection's remote (client) IP.
-   :field remote_part @added;v2.3.9: IMAP connection's remote (client) port.
+   :field remote_port @added;v2.3.9: IMAP connection's remote (client) port.
 
 
 .. dovecot_core:event:: imap_client_hibernated

--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -491,8 +491,8 @@ Authentication variables
 |          |                       | variable is populated with the client ID request as IMAP      |
 |          |                       | arglist.                                                      |
 |          |                       |                                                               |
-|          |                       | For directly logging the ID see                               |
-|          |                       | :dovecot_core:ref:`imap_id_log`.                              |
+|          |                       | For directly logging the ID see the                           |
+|          |                       | :dovecot_core:ref:`imap_id_received` event.                   |
 |          |                       |                                                               |
 |          |                       | .. versionadded:: v2.2.29                                     |
 +----------+-----------------------+---------------------------------------------------------------+

--- a/source/installation_guide/upgrading/from-2.3-to-3.0.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-3.0.rst
@@ -144,6 +144,8 @@ Removed features and their replacements
 | Dovecot director role                                      | This has been replaced with :ref:`Dovecot Cluster <dovecot_cluster_architecture>`,       |
 |                                                            | which is Pro-only feature.                                                               |
 +------------------------------------------------------------+------------------------------------------------------------------------------------------+
+| ``imap_id_log`` setting.                                   | Replaced by the :dovecot_core:ref:`imap_id_received` event.                              |
++------------------------------------------------------------+------------------------------------------------------------------------------------------+
 
 Changed default settings
 ========================

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -989,7 +989,7 @@ See :ref:`settings` for list of all setting groups.
 
 
 .. dovecot_core:setting:: imap_id_log
-   :todo: Indicate imap setting; Is there a list of ID fields?
+   :removed: v2.4.0;v3.0.0
    :values: @string
 
    The ID fields sent by the client that are output to the log.


### PR DESCRIPTION
Add the `imap_id_param` event description with its respective fields. Also deprecate references to the `imap_id_log` setting which is replaced by the new event.

Also fix some issues that cropped up on the event-page:
- Fix the manual class assignments that were used for styling the expand/collapse buttons and their respective functionality.
- Fix the `pop3_client` event that was incorrectly converted to a field_group before.
- Fix `local_part`/`remote_part` typo: `part` -> `port`.
- Drop the unnecessary and distracting animation-attribute of the sphinx-dropdowns.

Closes DOV-5738.