### PR TITLE
authentication/gssapi: Fix indentation

### DIFF
--- a/source/configuration_manual/authentication/gssapi.rst
+++ b/source/configuration_manual/authentication/gssapi.rst
@@ -50,7 +50,7 @@ Use klist on your Dovecot server to verify the keytab contains the expected resu
    Keytab name: FILE:/etc/krb5.keytab
    KVNO Principal
    ---- --------------------------------------------------------------------------
-      2 imap/hostname@REALM
+   2 imap/hostname@REALM
 
 Configuring Dovecot
 ===================


### PR DESCRIPTION
The indentation is correct for the command output, but sphinx has issues with it, so remove the extra indent to make it happy.

Broken in 1ad72462b8f0e57226ae6bf402fe7ef2bb2653af