### PR TITLE
recommend sieve_vacation_send_from_recipient = yes

### DIFF
--- a/source/configuration_manual/sieve/extensions/vacation.rst
+++ b/source/configuration_manual/sieve/extensions/vacation.rst
@@ -86,7 +86,7 @@ the ``plugin`` section (default values are indicated):
    Sieve script owner. Normally this is set to <>, which is the default
    in the specification. This is meant to prevent mail loops. However, 
    some mail servers block message with empty envelop sender (such as 
-   gmail), so it is recommended to set to `yes` instead.
+   gmail), so it is recommended to set to ``yes`` instead.
 
 Invalid values for the settings above will make the Sieve interpreter
 log a warning and revert to the default values.

--- a/source/configuration_manual/sieve/extensions/vacation.rst
+++ b/source/configuration_manual/sieve/extensions/vacation.rst
@@ -84,9 +84,9 @@ the ``plugin`` section (default values are indicated):
    This setting determines whether vacation messages are sent with the
    SMTP MAIL FROM envelope address set to the recipient address of the
    Sieve script owner. Normally this is set to <>, which is the default
-   as recommended in the specification. This is meant to prevent mail
-   loops. However, there are situations for which a valid sender address
-   is required and this setting can be used to accommodate for those.
+   in the specification. This is meant to prevent mail loops. However, 
+   some mail servers block message with empty envelop sender (such as 
+   gmail), so it is recommended to set to `yes` instead.
 
 Invalid values for the settings above will make the Sieve interpreter
 log a warning and revert to the default values.


### PR DESCRIPTION
Some mail server blocks empty envelop sender (such as gmail), so there is no reason to keep it default "no" value.

I debugged for a while why gmail threw me an error message of authentication check for my vacation message, but I already set SPF. Turns out that sieve_vacation_send_from_recipient = no was the reason, I have to change to sieve_vacation_send_from_recipient = yes instead.

>  This message does not pass authentication checks (SPF and DKIM both do 421-4.7.0 not pass). SPF check for [] (_sic_, empty bracket here) does not pass with ip: [XXXXX].To 421-4.7.0 best protect our users from spam, the message has been blocked.