### PR TITLE
DOV-5585: Remove sieve storage deprecations

### DIFF
--- a/source/_ext/dovecot_sphinx.py
+++ b/source/_ext/dovecot_sphinx.py
@@ -468,22 +468,36 @@ class DovecotEventDirective(DovecotDirective):
         entries = sorted(entries, key=lambda entry: entry[0])
 
         for key, content in entries:
+            subparts = None
+            kind = None
             parts = key.split(None, 1)
             if len(parts) == 2:
                 subparts = parts[1].split(";", 1)
-                if len(subparts) != 2 or subparts[0] != "@added":
+                if len(subparts) != 2:
                     raise ValueError("Invalid field modifier %s", parts[1])
-                added = subparts[1]
+                kind = subparts[0][1:]
                 key = parts[0]
-            else:
-                added = None
 
             row = nodes.row()
             row += nodes.entry("", nodes.literal(text=key))
             entry = nodes.entry()
             entry += content.children[0].deepcopy()
-            if added is not None:
-                entry += self._parse_rst(".. versionadded:: %s" % (added))
+            if kind == None:
+                pass
+            elif kind == "added":
+                entry += self._parse_rst(
+                    ".. versionadded:: %s" % (subparts[1])
+                )
+            elif kind == "changed":
+                entry += self._parse_rst(
+                    ".. versionchanged:: %s" % (subparts[1])
+                )
+            elif kind == "removed":
+                entry += self._parse_rst(
+                    ".. versionremoved:: %s" % (subparts[1])
+                )
+            else:
+                raise ValueError("Invalid field modifier %s", subparts[1])
             row += entry
             body += row
 

--- a/source/_ext/dovecot_sphinx.py
+++ b/source/_ext/dovecot_sphinx.py
@@ -502,9 +502,7 @@ class DovecotEventDirective(DovecotDirective):
             body += row
 
         """ Create collapsible container for event fields """
-        collapse = self._parse_rst(
-            ".. dropdown:: View Event Fields\n :animate: fade-in"
-        )
+        collapse = self._parse_rst(".. dropdown:: View Event Fields")
         collapse += table
         contentnode += collapse
 

--- a/source/admin_manual/event_design.rst
+++ b/source/admin_manual/event_design.rst
@@ -125,7 +125,7 @@ The fields can be used for various purposes:
 
 Example:
 
-   if all the networking events include ``ip``, ``bytes_in`` and ``bytes_out`` fields, statistics can globally track how much network traffic Dovecot is doing from its own point of view, regardless of whether it's HTTP traffic or IMAP traffic or something else.
+   if all the networking events include ``ip``, ``net_in_bytes`` and ``net_out_bytes`` fields, statistics can globally track how much network traffic Dovecot is doing from its own point of view, regardless of whether it's HTTP traffic or IMAP traffic or something else.
 
 Current naming conventions:
 ----------------------------
@@ -140,9 +140,8 @@ Current naming conventions:
 
      .. NOTE:: These are all different from incoming connection's IP/port fields. This is because often everything starts from an incoming connection, which will be used as the root event. So we may want to filter e.g. outgoing HTTP events going to port 80 which were initiated from IMAP clients that connected to ``port 993`` ``(port=80 local_port=993)``
 
-* Connection reads/writes should be counted in ``bytes_in`` and ``bytes_out`` fields
-   * These fields were chosen over e.g. ``network_in/out`` because a lot of code is rather generic and can work over TCP/IP or UNIX sockets, or maybe even any other kind of iostreams. Using a generic ``bytes_in/out`` makes it simpler to count these. If further differentiation is wanted on statistics side, networking events can be filtered out with ``ip``.
-   * These fields are usually easiest updated with ``event_add_int(event, bytes_in, istream->v_offset)`` and ``event_add_int(event, bytes_out, ostream->offset)``. If iostreams aren't used, ``event_inc_int()`` maybe be easier.
+* Connection reads/writes should be counted in ``net_in_bytes`` and ``net_out_bytes`` fields
+   * These fields are usually easiest updated with ``event_add_int(event, net_in_bytes, istream->v_offset)`` and ``event_add_int(event, net_out_bytes, ostream->offset)``. If iostreams aren't used, ``event_inc_int()`` maybe be easier.
 
 * (Local) disk reads should have ``disk_read`` and ``disk_write`` fields
    * With remote filesystems like NFS it may be difficult to differentiate between disk IO and network IO. Generally the ``disk_read/write`` should be used for ``POSIX read()`` and ``write()`` calls from filesystem.
@@ -153,9 +152,9 @@ Current naming conventions:
 
 * error_code=<value> : Machine-readable error code for a failed operation. If set, the ``error`` field must also be set.
 
-.. Note:: Events shouldn't be sent every time when receiving/sending network traffic. Instead, the ``bytes_in/out`` fields should be updated internally so that whenever the next event is sent it will have an updated traffic number.
+.. Note:: Events shouldn't be sent every time when receiving/sending network traffic. Instead, the ``net_in/out_bytes`` fields should be updated internally so that whenever the next event is sent it will have an updated traffic number.
 
-          Generally it's not useful for events to be counting operations. Rather each operation should be a separate event, and the statistics code should be the one counting them. This way statistics can only be counting e.g. operations with ``duration > 1 sec``. If the statistics code was seeing only bulk operation counts this wouldn't be possible. The ``bytes_in/out`` and such fields are more of an exception, because it would be too inefficient to send individual events each time those were updated.
+          Generally it's not useful for events to be counting operations. Rather each operation should be a separate event, and the statistics code should be the one counting them. This way statistics can only be counting e.g. operations with ``duration > 1 sec``. If the statistics code was seeing only bulk operation counts this wouldn't be possible. The ``net_in/out_bytes`` and such fields are more of an exception, because it would be too inefficient to send individual events each time those were updated.
 
 .. Note:: Even though internally updating a field for an event's parent will be immediately visible to its children, the update won't be automatically sent to the stats process. We may need to fix this if it becomes a problem.
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -974,6 +974,31 @@ POP3
    :field remote_port @added;v2.4.0,v3.0.0: POP3 connection's remote (client) port.
 
 
+.. dovecot_event:field_group:: pop3_command
+   :inherit: pop3_client
+
+   :field cmd_name @added;v2.4.0,v3.0.0: POP3 command name uppercased (e.g. ``UIDL``).
+   :field cmd_args @added;v2.4.0,v3.0.0: POP3 command's full parameters (e.g. ``1 1``).
+
+
+.. dovecot_core:event:: pop3_command_finished
+   :inherit: pop3_command
+   :added: v2.4.0;v3.0.0
+
+   :field reply: POP3 reply: Values:
+                                * ``OK``
+                                * ``FAIL``
+   :field net_in_bytes: Amount of data read for this command, in bytes.
+   :field net_out_bytes: Amount of data written for this command, in bytes.
+
+   POP3 command is completed.
+
+   This event is useful to track individual command usage, debug specific
+   sessions, and/or detect broken clients.
+
+   .. Note:: This event is currently not sent for pre-login POP3 commands.
+
+
 IMAP
 ====
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -1104,8 +1104,8 @@ IMAP Command
    :field running_usecs: How many usecs this command has spent running.
    :field lock_wait_usecs: How many usecs this command has spent waiting for
      locks.
-   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of data read, in bytes.
-   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of data written, in bytes.
+   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of data read for this command, in bytes.
+   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of data written for this command, in bytes.
 
    IMAP command is completed.
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -2150,8 +2150,18 @@ Events emitted by dictionary library and dictionary server.
 Login
 =====
 
+.. dovecot_event:field_group:: pre_login_client
+
+   :field local_ip: Local IP address.
+   :field local_port: Local port.
+   :field remote_ip: Remote IP address.
+   :field remote_port: Remote port.
+   :field user: Full username.
+   :field service: Name of service e.g. ``submission``, ``imap``.
+
 .. dovecot_core:event:: login_aborted
    :added: v2.4.0;v3.0.0
+   :inherit: pre_login_client
 
    :field reason: Short reason, see the short to long reason mapping in the table below.
    :field auth_successes: Number of successful authentications, which eventually failed due to other reasons.
@@ -2215,15 +2225,6 @@ Login Proxy
 ===========
 
 Events emitted when login process proxies a connection to a backend.
-
-.. dovecot_event:field_group:: pre_login_client
-
-   :field local_ip: Local IP address.
-   :field local_port: Local port.
-   :field remote_ip: Remote IP address.
-   :field remote_port: Remote port.
-   :field user: Full username.
-   :field service: Name of service e.g. ``submission``, ``imap``.
 
 .. dovecot_event:field_group:: login_proxy
    :inherit: pre_login_client

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -35,7 +35,6 @@ Categories
 **********
 
 .. dropdown:: Root Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75
@@ -117,7 +116,6 @@ Categories
         - Submission process
 
 .. dropdown:: Storage Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75
@@ -145,7 +143,6 @@ Categories
         - pop3c storage
 
 .. dropdown:: Mailbox Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75
@@ -159,7 +156,6 @@ Categories
         - Mail
 
 .. dropdown:: Sieve Categories
-   :animate: fade-in
 
    .. versionadded:: v2.3.11 makes the ``sieve`` category parent for the other
                      ``sieve-*`` categories.
@@ -183,7 +179,6 @@ Categories
         - Sieve storage
 
 .. dropdown:: SQL Categories
-   :animate: fade-in
 
    .. list-table::
       :widths: 25 75

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -563,8 +563,8 @@ These events apply only for connections using the ``connection API``.
 .. dovecot_core:event:: client_connection_disconnected
    :inherit: client_connection_common
 
-   :field bytes_in: Amount of data read, in bytes.
-   :field bytes_out: Amount of data written, in bytes.
+   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of data read, in bytes.
+   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of data written, in bytes.
    :field reason: Disconnection reason.
 
    Client connection is terminated.
@@ -888,8 +888,8 @@ a client to an external service.
 
    :field attempts: Amount of individual HTTP request attempts (number of
      retries after failures + 1).
-   :field bytes_in: Amount of data read, in bytes.
-   :field bytes_out: Amount of data written, in bytes.
+   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of data read, in bytes.
+   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of data written, in bytes.
    :field dest_host: Destination host.
    :field dest_ip: Destination IP address.
    :field dest_port: Destination port.
@@ -953,8 +953,8 @@ requests (e.g. doveadm HTTP API).
    :added: v2.3.18
    :inherit: http_server
 
-   :field bytes_in: Amount of request data read, in bytes.
-   :field bytes_out: Amount of response data written, in bytes.
+   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of request data read, in bytes.
+   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of response data written, in bytes.
    :field status_code: HTTP result status code (integer).
 
    HTTP request is fully completed, i.e. the incoming request body is read and
@@ -1104,8 +1104,8 @@ IMAP Command
    :field running_usecs: How many usecs this command has spent running.
    :field lock_wait_usecs: How many usecs this command has spent waiting for
      locks.
-   :field bytes_in: Amount of data read, in bytes.
-   :field bytes_out: Amount of data written, in bytes.
+   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of data read, in bytes.
+   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of data written, in bytes.
 
    IMAP command is completed.
 
@@ -2187,8 +2187,8 @@ Events emitted when login process proxies a connection to a backend.
    :field idle_usecs: Number of seconds the connection was idling before
      getting disconnected.
      .. versionchanged:: v2.4.0;v3.0.0 This was previously named idle_secs.
-   :field bytes_in: Amount of data read from client, in bytes.
-   :field bytes_out: Amount of data written to client, in bytes.
+   :field net_in_bytes @changed;v2.4.0,v3.0.0: Amount of data read from client, in bytes.
+   :field net_out_bytes @changed;v2.4.0,v3.0.0: Amount of data written to client, in bytes.
 
    Connection to proxy destination has ended, either successfully or with
    error.

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -2127,6 +2127,70 @@ Events emitted by dictionary library and dictionary server.
    Dictionary server finishes transaction.
 
 
+Login
+=====
+
+.. dovecot_core:event:: login_aborted
+   :added: v2.4.0;v3.0.0
+
+   :field reason: Short reason, see the short to long reason mapping in the table below.
+   :field auth_successes: Number of successful authentications, which eventually failed due to other reasons.
+   :field auth_attempts: Total number of authentication attempts, both successful and failed.
+   :field auth_usecs: How long ago the first authentication attempt was started.
+   :field connected_usecs: How long ago the client connection was created.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Reason
+     - Description
+   * - ``anonymous_auth_disabled``
+     - Anonymous authentication is not allowed.
+   * - ``authorization_failed``
+     - Master user authentication succeeded, but authorization to access the requested login user wasn't allowed.
+   * - ``auth_aborted_by_client``
+     - Client started SASL authentication, but returned "*" reply to abort it.
+   * - ``auth_failed``
+     - Generic authentication failure. Possibly due to invalid username/password, but could have been some other unspecified reason also.
+   * - ``auth_nologin_referral``
+     - Authentication returned auth referral to redirect the client to another server. This is normally configured to be sent only when the client is a Dovecot proxy, which handles the redirection.
+   * - ``auth_process_comm_fail``
+     - Internal error communicating with the auth process.
+   * - ``auth_process_not_ready``
+     - Client disconnected before auth process was ready. This may indicate a hanging auth process if ``connected_usecs`` is large.
+   * - ``auth_waiting_client``
+     - Client started SASL authentication, but disconnected instead of sending the next SASL continuation reply.
+   * - ``cleartext_auth_disabled``
+     - Authentication using cleartext mechanism is not allowed at this point. It would be allowed if SSL/TLS was enabled.
+   * - ``client_ssl_cert_untrusted``
+     - Client sent an SSL certificate that is untrusted with :dovecot_core:ref:`auth_ssl_require_client_cert` set to ``yes``
+   * - ``client_ssl_cert_missing``
+     - Client didn't send SSL certificate, but :dovecot_core:ref:`auth_ssl_require_client_cert` is set to ``yes``
+   * - ``client_ssl_not_started``
+     - Client didn't even start SSL with :dovecot_core:ref:`auth_ssl_require_client_cert` set to ``yes``
+   * - ``internal_failure``
+     - Internal failure. The error log has more details.
+   * - ``invalid_base64``
+     - Client sent invalid base64 in SASL response.
+   * - ``invalid_mech``
+     - Unknown SASL authentication mechanism requested.
+   * - ``login_disabled``
+     - The user has the :ref:`nologin<authentication-nologin>` field set in passdb and is thereby not able to login.
+   * - ``no_auth_attempts``
+     - Client didn't send any authentication attempts.
+   * - ``password_expired``
+     - The user's password is expired.
+   * - ``process_full``
+     - :ref:`service_configuration-client_limit` and :ref:`service_configuration-process_limit` was hit and this login session was killed.
+   * - ``proxy_dest_auth_failed``
+     - Local authentication succeeded, but proxying failed to authenticate to the destination hop.
+   * - ``shutting_down``
+     - The process is shutting down so the login is aborted.
+   * - ``user_disabled``
+     - User is in deny passdb, or in some other way disabled passdb.
+
+
 Login Proxy
 ===========
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -1113,6 +1113,28 @@ IMAP Command
    .. Note:: This event is currently not sent for pre-login IMAP commands.
 
 
+.. dovecot_core:event:: imap_id_received
+   :added: v2.4.0;v3.0.0
+   :inherit: imap_client
+
+   :field id_param_<param>: Received parameters. The event name is the lowercase
+                            parameter key prefixed with ``id_param_``, the value
+                            is the parameter value.
+   :field id_invalid<num>: Each key that contains invalid characters are
+                           enumerated starting with 1. Valid characters are
+                           latin alphabetic characters (= ``a`` .. ``z``),
+                           numerals (= ``0`` .. ``9``), the dash (= ``-``) and
+                           the underscore (= ``_``), every other character is
+                           considered invalid. The value of this field is the
+                           original parameter key including invalid characters,
+                           followed by a space character, and finally the
+                           original value concatenated into a single string.
+
+   This event is emitted when the IMAP ID command was received, both for pre-
+   as well as post-login. The parameters slightly differ for an unauthenticated
+   client, e.g. there is no user id.
+
+
 Mail Delivery
 =============
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -956,8 +956,11 @@ requests (e.g. doveadm HTTP API).
    the full response to the request has been sent to the client.
 
 
-POP3
-====
+..
+   Uncomment if there is an actual POP3 event.
+
+   POP3
+   ====
 
 .. dovecot_event:field_group:: pop3_client
 

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -672,6 +672,8 @@ Mail User
                  (Skipped in non-Linux environments.)
    :field syscw: Number of write syscalls
                  (Skipped in non-Linux environments.)
+   :field net_in_bytes @added;v2.4.0,v3.0.0: Bytes received during this session (for applicable processes.)
+   :field net_out_bytes @added;v2.4.0,v3.0.0: Bytes sent during this session (for applicable processes.)
 
 
 Mailbox

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -20,14 +20,14 @@ Page options:
 
    <script>
    function toggleTables(expand) {
-     $('details.dropdown').each(function() {
+     $('details.sd-dropdown').each(function() {
        $(this).attr('open', expand);
      });
    }
    </script>
 
-   <button type="button" class="btn btn-primary" onclick="toggleTables(true)">Expand All Tables</button>
-   <button type="button" class="btn btn-secondary" onclick="toggleTables(false)">Collapse All Tables</button>
+   <button type="button" class="sd-btn sd-btn-secondary" onclick="toggleTables(true)">Expand All Tables</button>
+   <button type="button" class="sd-btn sd-btn-secondary" onclick="toggleTables(false)">Collapse All Tables</button>
 
 
 **********

--- a/source/admin_manual/list_of_events.rst
+++ b/source/admin_manual/list_of_events.rst
@@ -1008,9 +1008,9 @@ IMAP Client
    :field user: Username of the user.
    :field session: Session ID of the IMAP connection.
    :field local_ip @added;v2.3.9: IMAP connection's local (server) IP.
-   :field local_part @added;v2.3.9: IMAP connection's local (server) port.
+   :field local_port @added;v2.3.9: IMAP connection's local (server) port.
    :field remote_ip @added;v2.3.9: IMAP connection's remote (client) IP.
-   :field remote_part @added;v2.3.9: IMAP connection's remote (client) port.
+   :field remote_port @added;v2.3.9: IMAP connection's remote (client) port.
 
 
 .. dovecot_core:event:: imap_client_hibernated

--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -491,8 +491,8 @@ Authentication variables
 |          |                       | variable is populated with the client ID request as IMAP      |
 |          |                       | arglist.                                                      |
 |          |                       |                                                               |
-|          |                       | For directly logging the ID see                               |
-|          |                       | :dovecot_core:ref:`imap_id_log`.                              |
+|          |                       | For directly logging the ID see the                           |
+|          |                       | :dovecot_core:ref:`imap_id_received` event.                   |
 |          |                       |                                                               |
 |          |                       | .. versionadded:: v2.2.29                                     |
 +----------+-----------------------+---------------------------------------------------------------+

--- a/source/configuration_manual/event_export.rst
+++ b/source/configuration_manual/event_export.rst
@@ -87,8 +87,8 @@ whitespace between the various tokens.
          "imap"
       ],
       "fields" : {
-         "bytes_in" : 7,
-         "bytes_out" : 311,
+         "net_in_bytes" : 7,
+         "net_out_bytes" : 311,
          "last_run_time" : "2019-06-19T10:38:25.422709Z",
          "lock_wait_usecs" : 60,
          "name" : "SELECT",
@@ -106,7 +106,7 @@ Example tab-text
 
 .. code-block:: none
 
-   event:imap_command_finished        hostname:dovecot-dev    start_time:2019-06-19T10:38:25.422744Z  end_time:2019-06-19T10:38:25.424812Z    category:imap   field:user=jeffpc       field:session=xlBB1KqLz1isGwB+  field:tag=a0005 field:name=SELECT       field:tagged_reply_state=OK     field:tagged_reply=OK [READ-WRITE] Select completed     field:last_run_time=2019-06-19T10:38:25.422709Z field:running_usecs=1953        field:lock_wait_usecs=60        field:bytes_in=7        field:bytes_out=311
+   event:imap_command_finished        hostname:dovecot-dev    start_time:2019-06-19T10:38:25.422744Z  end_time:2019-06-19T10:38:25.424812Z    category:imap   field:user=jeffpc       field:session=xlBB1KqLz1isGwB+  field:tag=a0005 field:name=SELECT       field:tagged_reply_state=OK     field:tagged_reply=OK [READ-WRITE] Select completed     field:last_run_time=2019-06-19T10:38:25.422709Z field:running_usecs=1953        field:lock_wait_usecs=60        field:net_in_bytes=7        field:net_out_bytes=311
 
 Transports
 ^^^^^^^^^^

--- a/source/configuration_manual/event_filter.rst
+++ b/source/configuration_manual/event_filter.rst
@@ -98,7 +98,7 @@ There are some limitations on which operators work with what field types:
 
 .. versionchanged:: v2.4.0;v3.0.0 Event fields have specific types that
                     constrain the possible values they can be filtered by. For
-                    example ``bytes_out`` and ``message_size`` are numeric and
+                    example ``net_out_bytes`` and ``message_size`` are numeric and
                     can only be matched against numeric values. Previously type
                     mismatches were silently ignored, beginning with this
                     version each type mismatch and unsupported operation
@@ -116,7 +116,7 @@ tokens, and therefore the following are all equivalent::
 A more complicated example::
 
   event=abc OR (event=def AND (category=imap OR category=lmtp) AND \
-    NOT category=debug AND NOT (bytes_in<1024 OR bytes_out<1024))
+    NOT category=debug AND NOT (net_in_bytes<1024 OR net_out_bytes<1024))
 
 .. versionadded:: v2.4.0;v3.0.0 Sizes can be expressed using the unit values
    ``B`` - which represents single byte values - as well as ``KB``, ``MB``,
@@ -128,7 +128,7 @@ A more complicated example::
 
 For example::
 
-  (category=debug AND NOT (bytes_in<1KB OR bytes_out<1KB)) OR \
+  (category=debug AND NOT (net_in_bytes<1KB OR net_out_bytes<1KB)) OR \
     (event=abc AND (message_size>1gb and message_size<1tB)) OR \
     (event=def AND (duration<1mins))
 

--- a/source/configuration_manual/service_configuration.rst
+++ b/source/configuration_manual/service_configuration.rst
@@ -30,7 +30,19 @@ If non-empty, this service is enabled only when the protocol name is listed in p
 
 idle_kill
 ^^^^^^^^^
-If a process doesn't appear to be doing anything after this much time, notify it that it should kill itself if it's not doing anything. ``process_min_avail`` setting overrides this. If set to ``0``, ``default_idle_kill`` is used.
+
+Time interval between killing extra idling processes. During the interval
+the master process tracks the lowest number of idling processes for the
+service. Afterwards it sends SIGINT notification to that many idling
+processes. If the processes are still idling when receiving the signal,
+they shut down themselves.
+
+If set to ``0``, :dovecot_core:ref:`default_idle_kill` is used.
+
+Using ``4294967295 secs`` disables the idle-killing.
+
+.. versionchanged:: v2.4.0;v3.0.0 This behavior was redesigned to work better
+		    in busy servers.
 
 Service privileges
 ==================

--- a/source/configuration_manual/sieve/examples.rst
+++ b/source/configuration_manual/sieve/examples.rst
@@ -328,17 +328,16 @@ The lookup directories can be specified with:
 .. code-block::
 
    plugin {
-     # Directory for :personal include scripts. The default is to use home directory.
-     sieve_dir = %h/sieve
+     # Directory where the sieve include plugin retrieves :personal scripts from.
+     sieve = file:~/sieve;active=~/.dovecot.sieve
 
-     # Directory for :global include scripts (not to be confused with sieve_global_path).
+     # Directory for :global include scripts (not to be confused with sieve_default).
      # If unset, the include fails.
-     sieve_global_dir = /etc/dovecot/sieve/
+     sieve_global = /etc/dovecot/sieve/
    }
 
-Both :pigeonhole:ref:`sieve_dir` and :pigeonhole:ref:`sieve_global_dir` may
-also be overridden by
-:ref:`userdb extra fields <authentication-user_extra_field>`.
+Both :pigeonhole:ref:`sieve` and :pigeonhole:ref:`sieve_global` may also be
+overridden by :ref:`userdb extra fields <authentication-user_extra_field>`.
 
 It's not currently possible to use subdirectories for the scripts.
 Having a '/' character in the script name always fails the include. This

--- a/source/configuration_manual/stats/index.rst
+++ b/source/configuration_manual/stats/index.rst
@@ -45,7 +45,7 @@ For example::
    metric imap_command {
      filter = event=imap_command_finished
 
-     fields = bytes_in bytes_out
+     fields = net_in_bytes net_out_bytes
      group_by = cmd_name tagged_reply_state
    }
 
@@ -187,7 +187,7 @@ range begins at ``min + 1`` and ends at ``min + step``, the next covers
 ``min + step + 1`` to ``min + (2 * step)``, and so on.  The last range
 covers ``max + 1`` to positive infinity.
 
-For example, given the specification ``bytes_out:linear:0:5000:1000``, the
+For example, given the specification ``net_out_bytes:linear:0:5000:1000``, the
 ranges would be:
 
 * (-inf, 0]
@@ -230,7 +230,7 @@ The above means:
    %95      95% of the IMAP commands took 188637 microseconds or less
 ========== ==================================================================================
 
-The other fields (than duration) track whatever that field represents. For example with imap_command_finished's bytes_in field could be tracking how many bytes were being used by the IMAP commands. Non-numeric fields can also be tracked, although only the ``count`` is relevant to those.
+The other fields (than duration) track whatever that field represents. For example with imap_command_finished's net_in_bytes field could be tracking how many bytes were being used by the IMAP commands. Non-numeric fields can also be tracked, although only the ``count`` is relevant to those.
 
 The list of fields can be specified with the ``-f`` parameter. The default is:
 
@@ -266,7 +266,7 @@ For example:
 
 .. code-block:: sh
 
-   doveadm stats add --description "IMAP SELECT commands" --exporter log-exporter --exporter-include "name timestamps" --fields "bytes_in bytes_out" --group-by "cmd_name tagged_reply_state" imap_cmd_select "event=imap_command_finished AND name=SELECT"
+   doveadm stats add --description "IMAP SELECT commands" --exporter log-exporter --exporter-include "name timestamps" --fields "net_in_bytes net_out_bytes" --group-by "cmd_name tagged_reply_state" imap_cmd_select "event=imap_command_finished AND name=SELECT"
 
 Metrics can be removed dynamically by running:
 

--- a/source/configuration_manual/stats/index.rst
+++ b/source/configuration_manual/stats/index.rst
@@ -21,6 +21,8 @@ In addition to the event filter, a list of fields that are included in the
 metrics can be specified using the ``fields`` setting.  All events have a
 default "duration" field that doesn't need to be listed explicitly.
 
+.. versionchanged:: v2.4.0,v3.0.0 All fields listed in ``fields`` are exported to OpenMetrics as well.
+
 Finally, the ``group_by`` metric setting can be used to dynamically generate
 sub-metrics based on fields' values.
 

--- a/source/configuration_manual/stats/openmetrics.rst
+++ b/source/configuration_manual/stats/openmetrics.rst
@@ -43,6 +43,8 @@ These are called ``dovecot_build_info`` and ``process_start_time_seconds``.
 
 .. versionchanged:: 2.3.14 Metric timestamps are dropped.
 
+.. versionchanged:: v2.4.0,v3.0.0 All fields listed in ``fields`` are exported too.
+
 Example
 =======
 

--- a/source/installation_guide/upgrading/from-2.3-to-3.0.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-3.0.rst
@@ -144,6 +144,8 @@ Removed features and their replacements
 | Dovecot director role                                      | This has been replaced with :ref:`Dovecot Cluster <dovecot_cluster_architecture>`,       |
 |                                                            | which is Pro-only feature.                                                               |
 +------------------------------------------------------------+------------------------------------------------------------------------------------------+
+| ``imap_id_log`` setting.                                   | Replaced by the :dovecot_core:ref:`imap_id_received` event.                              |
++------------------------------------------------------------+------------------------------------------------------------------------------------------+
 
 Changed default settings
 ========================

--- a/source/installation_guide/upgrading/from-2.3-to-3.0.rst
+++ b/source/installation_guide/upgrading/from-2.3-to-3.0.rst
@@ -260,3 +260,10 @@ And re-configure the ACL plugin:
 Afterwards you can remove the old global ACL directory parent::
 
    rm -rf /etc/dovecot/acls/
+
+
+Changes to statistics
+---------------------
+
+ - The ``bytes_in`` and ``bytes_out`` field in several events have been renamed as ``net_in_bytes`` and ``net_out_bytes``.
+   Check :ref:`list_of_events` for details.

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -569,10 +569,7 @@ See :ref:`settings` for list of all setting groups.
    :default: 1mins
    :values: @time
 
-   If a process is idle after this much time has elapsed, it is notified that
-   it should terminate itself if inactive.
-
-   This value can be overridden via the :ref:`service_configuration-idle_kill`
+   The default value to use for the :ref:`service_configuration-idle_kill`
    setting within service blocks.
 
 

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -989,7 +989,7 @@ See :ref:`settings` for list of all setting groups.
 
 
 .. dovecot_core:setting:: imap_id_log
-   :todo: Indicate imap setting; Is there a list of ID fields?
+   :removed: v2.4.0;v3.0.0
    :values: @string
 
    The ID fields sent by the client that are output to the log.

--- a/source/settings/pigeonhole.rst
+++ b/source/settings/pigeonhole.rst
@@ -172,9 +172,6 @@ Sieve Plugin Settings
    script manually in that case using the sievec command line tool, as
    explained :ref:`here <sieve_usage-compiling_sieve_script>`.
 
-   This setting used to be called :pigeonhole:ref:`sieve_global_path`, but
-   that name is now deprecated.
-
 
 .. pigeonhole:setting:: sieve_default_name
    :added: v0.4.8
@@ -190,11 +187,7 @@ Sieve Plugin Settings
    :default: ~/sieve
    :plugin: sieve
    :values: @string
-
-   .. deprecated:: v0.3.1
-
-      This location is configured as part of
-      :pigeonhole:ref:`sieve setting <sieve>`.
+   :removed: v0.5 Replaced with the :pigeonhole:ref:`sieve setting <sieve>`.
 
    Directory for :personal
    `include scripts <https://datatracker.ietf.org/doc/html/draft-ietf-sieve-include-05>`_
@@ -272,14 +265,9 @@ Sieve Plugin Settings
 .. pigeonhole:setting:: sieve_global_dir
    :plugin: sieve
    :values: @string
+   :removed: v0.5 Replaced with the :pigeonhole:ref:`sieve_global setting <sieve_global>`.
 
-   .. deprecated:: v0.3.1
-
-      A more generic version of this setting called
-      :pigeonhole:ref:`sieve_global` has been added and allows locations
-      other than file system directories.
-
-   Directory for ``:global`` include scripts for the include extension.
+   Location for ``:global`` include scripts for the Sieve include extension.
 
    The Sieve interpreter only recognizes files that end with a .sieve
    extension, so the include extension expects a file called name.sieve to
@@ -313,10 +301,8 @@ Sieve Plugin Settings
 .. pigeonhole:setting:: sieve_global_path
    :plugin: sieve
    :values: @string
+   :removed: v0.5 Replaced with the :pigeonhole:ref:`sieve_default setting <sieve_default>`.
 
-   .. deprecated:: v0.2
-
-      Replaced by :pigeonhole:ref:`sieve_default`.
 
 .. pigeonhole:setting:: sieve_implicit_extensions
    :added: v0.4.13


### PR DESCRIPTION
Remove the following deprecated parts:
- Mark deprecated sieve storage settings 'sieve_dir', 'sieve_global_path', and 'sieve_global_dir' as removed,
- update sieve include extension examples with the current sieve storage settings.

Closes DOV-5585.