### PR TITLE
protocols/imap: Remove completely wrong duplicated content

### DIFF
--- a/source/configuration_manual/protocols/imap.rst
+++ b/source/configuration_manual/protocols/imap.rst
@@ -1,37 +1,8 @@
 .. _imap:
 
-======================================
- Authentication via remote IMAP server
-======================================
-
-Available driver settings:
-
-* host=<template> : IP address or hostname. Allows :ref:`config_variables` (e.g. host=imap.%d)
-* port=<port>
-* username=<template> : The default is %u, but this could be changed to for
-  example %n@example.com
-* ssl=imaps / ssl=starttls
-
- * ssl_ca_dir=<path>
- * ssl_ca_file=<path> (v2.2.30+)
- * allow_invalid_cert=yes|no : Whether to allow authentication even if the
-   certificate isn't trusted. For v2.2 it defaults to "yes". (v2.2.30+)
-
-*  rawlog_dir=<path>
-
-See also `HowTo/ImapcProxy <https://wiki.dovecot.org/HowTo/ImapcProxy>`_ for
-how to combine this with imapc storage.
-
-Example:
-
-Authenticates users against remote IMAP server in IP address 192.168.1.123:
-
-.. code-block:: none
-
-  passdb {
-    driver = imap
-    args = host=192.168.1.123
-  }
+====
+IMAP
+====
 
 IMAP Backend Configuration
 ==========================


### PR DESCRIPTION
This page, or all the protocols pages in general, could use some rewriting.