### PR TITLE
pigeonhole-man: Remove scriptname argument

### DIFF
--- a/source/pigeonhole-man/doveadm-sieve.1.rst.in
+++ b/source/pigeonhole-man/doveadm-sieve.1.rst.in
@@ -75,9 +75,9 @@ not be the active script, unless the **-a** option is present.
 sieve list
 ----------
 
-**doveadm sieve list** [**-A** | **-u** *user*] [**-S** *socket_path*] *scriptname*
+**doveadm sieve list** [**-A** | **-u** *user*] [**-S** *socket_path*]
 
-Use this command to get an overview of existing Sieve scripts.
+List existing Sieve scripts, and their active state.
 
 sieve rename
 ------------


### PR DESCRIPTION
This is the bootsrap command that gets scriptnames; you don't need to pass one in.

Also, indicate that this command returns both the script name and the active status.