### PR TITLE
Only run spectral when it could work

### DIFF
--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -10,7 +10,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       if: ${{ env.SPECTRAL_DSN != '' }}
     - name: Install and run Spectral CI
       uses: spectralops/spectral-github-action@v2

--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      if: ${{ env.SPECTRAL_DSN != '' }}
     - name: Install and run Spectral CI
       uses: spectralops/spectral-github-action@v2
+      if: ${{ env.SPECTRAL_DSN != '' }}
       with:
         spectral-dsn: ${{ env.SPECTRAL_DSN }}
         spectral-args: scan --ok  --include-tags base,audit3


### PR DESCRIPTION
When I upgraded my fork, I got failures from this workflow: https://github.com/check-spelling-sandbox/dovecot-documentation/actions/workflows/spectral.yml

This adds a look-before-you-leap check which saves ~30s of useless cpu cycles for my org but would still allow me to use the workflow if I configured the secret.