### PR TITLE
DOV-6305: Rewrite `import_environment` and `imap_id_send` as strlist

### DIFF
--- a/source/admin_manual/debugging/debugging_rawlog.rst
+++ b/source/admin_manual/debugging/debugging_rawlog.rst
@@ -104,7 +104,9 @@ You can also set DEBUG environment to have rawlog log an info message why it's n
 
 .. code-block:: none
 
- import_environment=$import_environment DEBUG=1
+ import_environment {
+   DEBUG = 1
+ }
  
 Configuration
 -------------

--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -19,20 +19,23 @@ Global variables
 
 Global variables that work everywhere are:
 
-+----------------+-----------------------------------------------------------------------------+
-| Long name      |  Description                                                                |
-+================+=============================================================================+
-| %%             | '%' character. See :ref:`user_shared_mailboxes`                             |
-|                | for further information about %% variables                                  |
-+----------------+-----------------------------------------------------------------------------+
-| env:<name>     | Environment variable <name>                                                 |
-+----------------+-----------------------------------------------------------------------------+
-| system:<name>  | Get a system variable, see :ref:`below <variables-system-variables>`        |
-|                | for list of supported names.                                                |
-+----------------+-----------------------------------------------------------------------------+
-| process:<name> | Get a process variable, see :ref:`below <variables-process-variables>`      |
-|                | for list of supported names.                                                |
-+----------------+-----------------------------------------------------------------------------+
++----------------+----------------------------------------------------------------------------------+
+| Long name      |  Description                                                                     |
++================+==================================================================================+
+| %%             | '%' character. See :ref:`user_shared_mailboxes`                                  |
+|                | for further information about %% variables                                       |
++----------------+----------------------------------------------------------------------------------+
+| env:<name>     | Environment variable <name>                                                      |
++----------------+----------------------------------------------------------------------------------+
+| system:<name>  | Get a system variable, see :ref:`below <variables-system-variables>`             |
+|                | for list of supported names.                                                     |
++----------------+----------------------------------------------------------------------------------+
+| process:<name> | Get a process variable, see :ref:`below <variables-process-variables>`           |
+|                | for list of supported names.                                                     |
++----------------+----------------------------------------------------------------------------------+
+| dovecot:<key>  | Get a distribution variable, see :ref:`below <variables-distribution-variables>` |
+|                | for a list of supported names.                                                   |
++----------------+----------------------------------------------------------------------------------+
 
 If :ref:`var_expand_crypt_plugin` is loaded, these also work globally:
 
@@ -60,6 +63,12 @@ Supported system variables
 ``hostname``
   Hostname (without domain). Can be overridden with ``DOVECOT_HOSTNAME`` environment variable.
   This needs to be included in :dovecot_core:ref:`import_environment`.
+``os``
+  OS name reported by ``uname()`` call.
+  (Similar to ``uname -s`` output.)
+``os-version``
+  OS version reported by ``uname()`` call.
+  (Similar to ``uname -r`` output.)
 
 .. _variables-process-variables:
 
@@ -72,6 +81,26 @@ Supported process variables
   Effective user ID of the current process.
 ``gid``
   Effective group ID of the current process.
+
+.. _variables-distribution-variables:
+
+Dovecot Distribution Attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``name``
+  Name of distributed package
+  (Default: ``Dovecot``)
+``version``
+  Dovecot version
+``support-url``
+  Support webpage set in Dovecot distribution
+  (Default: ``https://www.dovecot.org/``)
+``support-email``
+  Support email set in Dovecot distribution
+  (Default: ``dovecot@dovecot.org``)
+``revision``
+  Short commit hash of Dovecot git source tree HEAD
+  (same as the commit hash reported in ``dovecot --version``)
 
 .. _variables-user:
 

--- a/source/configuration_manual/general_backend_settings.rst
+++ b/source/configuration_manual/general_backend_settings.rst
@@ -35,7 +35,9 @@ user connection will be using both old and new configuration at the same time.
 
 .. code-block:: none
 
-  import_environment = $import_environment MALLOC_MMAP_THRESHOLD_=131072
+  import_environment {
+    MALLOC_MMAP_THRESHOLD_ = 131072
+  }
 
 Allocate all memory larger than 128 kB using mmap(). This allows the OS to free
 the memory afterwards. This is important for backends because there can be a

--- a/source/configuration_manual/resource_usage.rst
+++ b/source/configuration_manual/resource_usage.rst
@@ -37,6 +37,8 @@ If enabled, everything except `save` event will log only the fields that can be 
 
 .. code-block:: none
 
-   import_environment = $import_environment MALLOC_MMAP_THRESHOLD_=131072
+   import_environment {
+     MALLOC_MMAP_THRESHOLD_ = 131072
+   }
 
 Avoid processes permanently using too much memory by having it use ``mmap()`` for ``>=128 kB`` memory allocations.

--- a/source/configuration_manual/system_calls_optimization.rst
+++ b/source/configuration_manual/system_calls_optimization.rst
@@ -26,7 +26,9 @@ or directly from inside the dovecot configuration file:
 
 ::
 
-  import_environment = $import_environment TZ=:/etc/localtime
+  import_environment {
+    TZ = :/etc/localtime
+  }
 
 Note that a reload is not sufficient for the change to take effect. A restart
 is required.

--- a/source/developer_manual/development_tips/valgrind.rst
+++ b/source/developer_manual/development_tips/valgrind.rst
@@ -83,4 +83,8 @@ unloading. This will cause some extra warnings about leaking memory in
 dl*() functions which can be ignored. You can also do this in
 dovecot.conf:
 
-``import_environment = $import_environment GDB=1``
+.. code-block::
+
+  import_environment {
+    GDB = 1
+  }

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -1111,40 +1111,24 @@ See :ref:`settings` for list of all setting groups.
 
 
 .. dovecot_core:setting:: imap_id_send
-   :default: name *
+   :default: name=%{dovecot:name}
    :todo: Indicate imap setting
-   :values: @string
+   :values: @strlist
 
    Which ID field names and values to send to clients.
 
-   Using ``*`` as the value makes Dovecot use the default value.
-
-   There are currently defaults for the following fields:
-
-   ================= ==========================================================
-   Field             Default
-   ================= ==========================================================
-   ``name``          Name of distributed package (Default: ``Dovecot``)
-   ``version``       Dovecot version
-   ``os``            OS name reported by uname syscall (similar to ``uname -s``
-                     output)
-   ``os-version``    OS version reported by uname syscall (similar to ``uname
-                     -r`` output)
-   ``support-url``   Support webpage set in Dovecot distribution (Default:
-                     ``http://www.dovecot.org/``)
-   ``support-email`` Support email set in Dovecot distribution (Default:
-                     ``dovecot@dovecot.org``)
-   ``revision``      Short commit hash of Dovecot git source tree HEAD (same
-                     as the commit hash reported in ``dovecot --version``)
-
-                     .. dovecotadded:: 2.3.10
-   ================= ==========================================================
+   You can access default values by using
+   :ref:`variables-distribution-variables`.
 
    Example:
 
    .. code-block:: none
 
-     imap_id_send = "name" * "version" * support-url http://example.com/
+     imap_id_send {
+       name = %{dovecot:name}
+       version = %{dovecot:version}
+       support-url = http://example.com/
+     }
 
 
 .. dovecot_core:setting:: imap_idle_notify_interval

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -1319,15 +1319,24 @@ See :ref:`settings` for list of all setting groups.
 
 
 .. dovecot_core:setting:: import_environment
-   :default: TZ CORE_OUTOFMEM CORE_ERROR
+   :default: TZ=%{env:TZ} CORE_OUTOFMEM=%{env:CORE_OUTOFMEM} CORE_ERROR=%{env:CORE_ERROR}
    :todo: Explain default variables
-   :values: @string
+   :values: @strlist
 
-   A list of environment variables, space-separated, that are preserved and
-   passed to all child processes.
+   A list of environment key=value pairs, that are preserved and passed to all
+   child processes.
 
-   It can include key = value pairs for assigning variables the desired value
-   upon Dovecot startup.
+   The value can be determined from the existing environment upon Dovecot
+   startup or directly specified.
+
+   Example:
+
+   .. code-block:: none
+
+     import_environment {
+       TZ = :/etc/localtime
+       TMPDIR = /dovecot-tmp
+     }
 
 
 .. dovecot_core:setting:: info_log_path

--- a/source/settings/core.rst
+++ b/source/settings/core.rst
@@ -1319,7 +1319,7 @@ See :ref:`settings` for list of all setting groups.
 
 
 .. dovecot_core:setting:: import_environment
-   :default: TZ=%{env:TZ} CORE_OUTOFMEM=%{env:CORE_OUTOFMEM} CORE_ERROR=%{env:CORE_ERROR}
+   :default: TZ=%{env:TZ} CORE_OUTOFMEM=%{env:CORE_OUTOFMEM} CORE_ERROR=%{env:CORE_ERROR} PATH=%{env:PATH}
    :todo: Explain default variables
    :values: @strlist
 


### PR DESCRIPTION
- Add new distribution attributes, accessible via `%{dovecot:<key>}` syntax,
- add `os` as well as `os-release` variables to `system:` key,
- document changes of `imap_id_send` rewrite as strlist, and
- document changes of `import_environment` rewrite as strlist.