### PR TITLE
Improve `director_with_lua.rst`

### DIFF
--- a/source/configuration_manual/howto/director_with_lua.rst
+++ b/source/configuration_manual/howto/director_with_lua.rst
@@ -27,7 +27,7 @@ This script can use any SQL driver supported by `Lua DBI <https://github.com/mwi
 
 If you have multiple Dovecot proxies, they all need the same data to route users to the correct
 backend. Therefore, if you use a database engine that supports data replication (such as MySQL or
-PostgreSQL), you can run the Lua script on each of your proxies.
+PostgreSQL), you can run the script on each of your proxies.
 
 You will need `Lua DBI <https://github.com/mwild1/luadbi>`_, and a database driver for it.
 For the shard version, you will need to install `CRC32 library <https://github.com/hjelmeland/luacrc32>`_.
@@ -68,6 +68,7 @@ And schema for the sharded version.
      PRIMARY KEY (backend_id, user_hash)
   );
 
+The user is routed to the backend in the `user_backend` table. If no entry exists, the script creates one.
 
 Configuration
 -------------

--- a/source/configuration_manual/howto/director_with_lua.rst
+++ b/source/configuration_manual/howto/director_with_lua.rst
@@ -98,8 +98,9 @@ If you wish to do authentication, you can do
   }
 
 
-If you are using MySQL or PostgreSQL, you can also install this directly on your proxy node(s),
-and skip having a centralized director node.
+If you have multiple Dovecot proxies, they all need the same data to route users to the correct
+backend. Therefore, if you use a database engine that supports data replication (such as MySQL or
+PostgreSQL), you can run the Lua script on each of your proxies.
 
 Operations
 ----------

--- a/source/configuration_manual/howto/director_with_lua.rst
+++ b/source/configuration_manual/howto/director_with_lua.rst
@@ -17,9 +17,6 @@ The Lua script comes in two variants, first one simply does username <-> hostnam
 and can be found at `<https://github.com/dovecot/tools/blob/main/director.lua>`_.
 The second does sharding and can be found at `<https://github.com/dovecot/tools/blob/main/director-shard.lua>`_.
 
-In database, the backend\_ip field can be left empty when it's not needed.
-It can be used when your backend names cannot be resolved.
-
 The script can be run on a proxy directly, or one can have one dedicated proxy node acting
 as a Lua director node running the script.
 

--- a/source/configuration_manual/howto/director_with_lua.rst
+++ b/source/configuration_manual/howto/director_with_lua.rst
@@ -24,7 +24,10 @@ Prerequisites
 -------------
 
 This script can use any SQL driver supported by `Lua DBI <https://github.com/mwild1/luadbi>`_.
-If you want to use SQLite, or some other file based database, you can only run this on a single node.
+
+If you have multiple Dovecot proxies, they all need the same data to route users to the correct
+backend. Therefore, if you use a database engine that supports data replication (such as MySQL or
+PostgreSQL), you can run the Lua script on each of your proxies.
 
 You will need `Lua DBI <https://github.com/mwild1/luadbi>`_, and a database driver for it.
 For the shard version, you will need to install `CRC32 library <https://github.com/hjelmeland/luacrc32>`_.
@@ -97,10 +100,6 @@ If you wish to do authentication, you can do
     args = file=/etc/dovecot/director.lua noauthenticate
   }
 
-
-If you have multiple Dovecot proxies, they all need the same data to route users to the correct
-backend. Therefore, if you use a database engine that supports data replication (such as MySQL or
-PostgreSQL), you can run the Lua script on each of your proxies.
 
 Operations
 ----------

--- a/source/configuration_manual/howto/director_with_lua.rst
+++ b/source/configuration_manual/howto/director_with_lua.rst
@@ -105,5 +105,5 @@ PostgreSQL), you can run the Lua script on each of your proxies.
 Operations
 ----------
 
-There are no built-in tools in Dovecot to manage the state in the database, you need to
-build your own tooling.
+There are no built-in tools in Dovecot to manage the database (such as adding backends,
+kicking users, monitoring backends, etc.). You need to build your own tooling.

--- a/source/configuration_manual/howto/director_with_lua.rst
+++ b/source/configuration_manual/howto/director_with_lua.rst
@@ -68,7 +68,9 @@ And schema for the sharded version.
      PRIMARY KEY (backend_id, user_hash)
   );
 
-The user is routed to the backend in the `user_backend` table. If no entry exists, the script creates one.
+The user is routed to the backend in the `user_backend` table. If no entry exists, the script
+creates one. If you used Dovecot 2.x's `director_tag` functionality, you can create an entry
+yourself with the appropriate backend.
 
 Configuration
 -------------


### PR DESCRIPTION
From my perspective as a user looking to migrate from Dovecot 2.x's Director to 'Lua director', the documentation assumes the reader has certain knowledge. This PR attempts to fix that.