### PR TITLE
DOV-6456: Update IMAP Password Database

### DIFF
--- a/source/configuration_manual/authentication/authentication_via_remote_imap_server.rst
+++ b/source/configuration_manual/authentication/authentication_via_remote_imap_server.rst
@@ -4,15 +4,30 @@
 Authentication via remote IMAP server
 =====================================
 
-Available driver settings:
+This method is a separate IMAP server that authenticates the requested user
+against its internal database.
 
-* host=<template> : IP address or hostname. Allows
-  :ref:`%variables <config_variables>` (e.g. ``host=imap.%d``)
-* port=<port>
-* username=<template> : The default is %u, but this could be changed to for
-  example %n@example.com
-* ssl=imaps / ssl=starttls
-* rawlog_dir=<path>
+Configuration
+=============
+
+.. dovecot_core:setting_link:: imapc_host
+
+
+.. dovecot_core:setting_link:: imapc_port
+
+
+.. dovecot_core:setting_link:: imapc_user
+
+
+.. dovecot_core:setting_link:: imapc_rawlog_dir
+
+
+.. dovecot_core:setting_link:: imapc_ssl
+
+
+.. dovecotremoved:: 2.4.0,3.0.0 Arg-based driver settings have been removed
+                    in favor of using the standard imapc_* settings.
+
 
 .. dovecotremoved:: 2.4.0,3.0.0 ssl_ca_file, ssl_ca_dir and allow_invalid_cert
                     settings have been removed. The standard ssl_* settings can
@@ -28,5 +43,11 @@ Authenticates users against remote IMAP server in IP address 192.168.1.123:
 .. code-block:: none
 
   passdb imap {
-    args = host=192.168.1.123
+    imapc_host = 192.168.1.123
+    imapc_port = 143
+    imapc_user = %{owner_user}
+    imapc_rawlog_dir = /tmp/imapc_rawlogs/
+    imapc_ssl = starttls
+
+    ssl_client_require_valid_cert = no
   }

--- a/source/configuration_manual/authentication/password_databases_passdb.rst
+++ b/source/configuration_manual/authentication/password_databases_passdb.rst
@@ -58,7 +58,7 @@ with non-cleartext :ref:`authentication-authentication_mechanisms`.
 Databases that belong to this category are:
 
 * **PAM**: Pluggable Authentication Modules. See :ref:`authentication-pam`.
-* **IMAP**: Authenticate against remote IMAP server. See :ref:`imap`.
+* **IMAP**: Authenticate against remote IMAP server. See :ref:`authentication-authentication_via_remote_imap_server`.
 * **OAuth2**: Authenticate against oauth2 provider. See :ref:`authentication-oauth2`.
 * **BSDAuth**: BSD authentication (deprecated, unsupported). See :ref:`authentication-bsdauth`.
 

--- a/source/configuration_manual/config_file/config_variables.rst
+++ b/source/configuration_manual/config_file/config_variables.rst
@@ -521,6 +521,11 @@ Authentication variables
 |          |                       | .. dovecotadded:: 2.2.13 Works in auth process.               |
 |          |                       | .. dovecotdeprecated:: 2.3.13                                 |
 +----------+-----------------------+---------------------------------------------------------------+
+|          | owner_user            | For shared storage this is the %{user} variable of the owner, |
+|          |                       | otherwise it is the same as %{user}.                          |
+|          |                       |                                                               |
+|          |                       | .. dovecotadded:: 2.4.0,3.0.0                                 |
++----------+-----------------------+---------------------------------------------------------------+
 |          | passdb:<name>         | Return passdb extra field "name". %{passdb:name:default}      |
 |          |                       | returns "default" if "name" doesn't exist (not returned if    |
 |          |                       | name exists but is empty). Note that this doesn't work in     |

--- a/source/configuration_manual/mail_location/imapc/index.rst
+++ b/source/configuration_manual/mail_location/imapc/index.rst
@@ -30,6 +30,13 @@ Connection Settings
    server before disconnecting and retrying.
 
 
+.. dovecot_core:setting:: imapc_connection_timeout_interval
+   :default: 30 secs
+   :values: @time_msecs
+
+   How long to wait before considering a connection attempt as timed out.
+
+
 .. dovecot_core:setting:: imapc_connection_retry_count
    :default: 1
    :values: @uint
@@ -241,14 +248,12 @@ Connection Settings
 
 
 .. dovecot_core:setting:: imapc_max_line_length
-   :default: 0
+   :default: unlimited
    :values: @size
 
    The maximum line length to accept from the remote IMAP server.
 
    This setting is used to limit maximum memory usage.
-
-   A value of ``0`` indicates no maximum.
 
 
 .. dovecot_core:setting:: imapc_password
@@ -316,6 +321,9 @@ Connection Settings
    production use.
 
    Only used if :dovecot_core:ref:`imapc_ssl` is enabled.
+
+   .. dovecotremoved:: 2.4.0,3.0.0 Dropped in favor of using the global
+                       :dovecot_core:ref:`ssl_client_require_valid_cert`.
 
 
 .. dovecot_core:setting:: imapc_user

--- a/source/configuration_manual/mail_location/imapc/index.rst
+++ b/source/configuration_manual/mail_location/imapc/index.rst
@@ -319,6 +319,7 @@ Connection Settings
 
 
 .. dovecot_core:setting:: imapc_user
+   :default: %{owner_user}
    :seealso: @imapc_master_user;dovecot_core, @imapc_password;dovecot_core
    :values: @string
 

--- a/source/configuration_manual/shared_mailboxes/cluster_setup.rst
+++ b/source/configuration_manual/shared_mailboxes/cluster_setup.rst
@@ -93,7 +93,7 @@ Additionally imapc must be configured accordingly on the backends:
 ::
 
    imapc_host = proxy-load-balancer
-   #imapc_user = # leave this empty. It'll be automatically filled with the destination username.
+   #imapc_user = %{owner_user} # This %variable will be automatically filled with the destination username.
    imapc_password = master-secret
    # With v2.4.0;v3.0.0 the following features are enabled by default, prior to
    # this version the following must be uncommented:

--- a/source/configuration_manual/shared_mailboxes/cluster_setup_example.rst
+++ b/source/configuration_manual/shared_mailboxes/cluster_setup_example.rst
@@ -43,7 +43,7 @@ Dovecot Backend configuration snippet
 
         imapc_host = <proxy-load-balancer>
         imapc_password = imapcpass
-        imapc_user = # empty defaults to shared user
+        imapc_user = %{owner_user}
         # With v2.4.0;v3.0.0 the following features are enabled by default,
         # prior to this version the following must be uncommented:
         #imapc_features = fetch-bodystructure fetch-headers rfc822.size search modseq acl delay-login


### PR DESCRIPTION
- Document `%{owner_user}` %variable,
- update default value of `imapc_user`,
- update default value of `imapc_max_line_length`, 
- add `imapc_connection_timeout_interval` setting,
- mark `imapc_ssl_verify` as removed, and
- update IMAP Password Database description with links to the proper settings and updated example.

Closes DOV-6456.