### PR TITLE
vitepress: Fix 404's in sidebar

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -65,7 +65,7 @@ export default defineConfig({
 			includeFolderIndexFile: true,
 			collapseDepth: 1,
 			excludeFiles: [],
-			excludeFilesByFrontmatterName: 'exclude',
+			excludeFilesByFrontmatterFieldName: 'exclude',
 			sortMenusByName: true,
 		}),
 


### PR DESCRIPTION
sidebar plugin had an API change that was ignoring exclude directive in frontmatter for placeholder files.