### PR TITLE
vitepress: Disable default link checking on build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
         run: npm ci
       - name: Build with VitePress
         run: |
-          npm run docs:build-ci
+          npm run docs:build

--- a/lib/link_checker.js
+++ b/lib/link_checker.js
@@ -1,6 +1,6 @@
 import getHrefs from 'get-hrefs'
 import linkCheck from 'link-check'
-import { isCIBuild } from './utility.js'
+import { doBuildChecks } from './utility.js'
 
 const linkCache = {}
 const linkErrors = []
@@ -12,18 +12,11 @@ const ignores = [
 	// Ignore localhost links
 	'://localhost',
 	// Ignore example data
-	'http://10.10.10.1',
-	'http://host:9090',
-	// Ignore datastax links (possibly related to ALPN/HTTP 2.0 resolution:
-	// https://github.com/tcort/link-check/issues/72; wget and curl do not
-	// work by default from command line either)
-	'https://docs.datastax.com/',
-	'https://support.cpanel.net/',
-	'https://forums.cpanel.net',
+	'://10.10.10.1',
 ]
 
 export function checkExternalLinks(context, extra_ignores = []) {
-	if (isCIBuild()) {
+	if (!doBuildChecks()) {
 		return
 	}
 

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -170,9 +170,8 @@ export function resolveURL(url, base) {
 	return (base.endsWith('/') ? base.slice(0, -1) : base) + '/' + url
 }
 
-export function isCIBuild() {
+export function doBuildChecks() {
 	// Running a local dev environment is considered a "CI build", since
 	// we should not be doing expensive validity checking
-	return (process.env.npm_lifecycle_event === 'docs:build-ci') ||
-			(process.env.NODE_ENV === 'development')
+	return (process.env.npm_lifecycle_event === 'docs:build-checks')
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",
-    "docs:build-ci": "vitepress build",
+    "docs:build-checks": "vitepress build",
     "docs:preview": "vitepress preview",
     "man:build": "node util/generate_man.js"
   },


### PR DESCRIPTION
It is too unstable at the moment. Not sure if it is a library limitation or something else.

Move this checking to an explicit 'npm run docs:build-checks' command.

Thus, both CI and deployment builds will ignore (for now).