### PR TITLE
vitepress: enable metaChunk setting

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -46,6 +46,7 @@ export default defineConfig({
 	},
 
 	ignoreDeadLinks: 'localhostLinks',
+	metaChunk: true,
 
 	themeConfig: {
 		nav: [


### PR DESCRIPTION
This removes an ~30KB chunk of code from all ~300 individual pages, and moves to a centralized, cacheable javascript file.

See: https://vitepress.dev/reference/site-config#metachunk