### PR TITLE
DOV-6762: Add support for obox specific setting links

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -133,6 +133,7 @@ function dovecot_markdown(md, opts) {
 		const parts = token.attrGet('parts')
 
 		let hash = ''
+		let url = ''
 
 		switch (mode) {
 		case 'added':
@@ -153,10 +154,13 @@ function dovecot_markdown(md, opts) {
 		case 'doveadm':
 		case 'event':
 		case 'setting':
+		case 'obox':
 			env.inner = parts[1]
 			env.args = parts[2] ? parts[2] : undefined;
 
+			let base_url = 'core/summaries'
 			let page = mode
+			let search_str = ''
 			switch (mode) {
 			case 'doveadm':
 				if (!opts.doveadm[env.inner]) {
@@ -173,10 +177,25 @@ function dovecot_markdown(md, opts) {
 				page += 's'
 				break
 
+			case 'obox':
+				/* Settings names can have brackets, so we need to unescape
+				 * input for purposes of searching settings keys. */
+				search_str = env.inner.replaceAll('&gt;', '<')
+						.replaceAll('&lt;', '>')
+
+				if (!opts.settings[search_str]) {
+					throw new Error('obox link missing: ' + env.inner)
+				}
+
+				/* Obox configuration links must point to a different page
+				 * than the default settings page. */
+				base_url = 'obox'
+				page = 'configuration'
+				break
 			case 'setting':
 				/* Settings names can have brackets, so we need to unescape
 				 * input for purposes of searching settings keys. */
-				const search_str = env.inner.replaceAll('&gt;', '<')
+				search_str = env.inner.replaceAll('&gt;', '<')
 						.replaceAll('&lt;', '>')
 
 				if (!opts.settings[search_str]) {
@@ -186,12 +205,11 @@ function dovecot_markdown(md, opts) {
 				break
 			}
 
-			return '<code><a href="' +
-				resolveURL('core/summaries/' + page + '.html#' + env.inner,
-					opts.base) + '">'
+			url = `${base_url}/${page}.html#${env.inner}`
+			return `<code><a href="${resolveURL(url, opts.base)}">`
 
 		case 'link':
-			let url = '#'
+			url = '#'
 			env.inner = false
 
 			if (!opts.dovecotlinks[parts[1]]) {
@@ -319,6 +337,7 @@ function dovecot_markdown(md, opts) {
 			return 'RFC ' + env.inner +
 				(env.args ? ' (section ' + env.args + ')' : '')
 
+		case 'obox':
 		case 'setting':
 			return env.inner + (env.args ? ' = ' + env.args : '')
 
@@ -342,6 +361,7 @@ function dovecot_markdown(md, opts) {
 		case 'event':
 		case 'man':
 		case 'setting':
+		case 'obox':
 		case 'variable':
 			return '</a></code>'
 


### PR DESCRIPTION
This PR adds support for Dovecot Pro specific `obox` settings, that need to link into a different page.