### PR TITLE
man: Fix include paths in include files

### DIFF
--- a/docs/core/man/include/doveadm-backup-sync.inc
+++ b/docs/core/man/include/doveadm-backup-sync.inc
@@ -102,13 +102,13 @@ server processes to be running, except when using -u parameter to do a
 dsync can sync either one or multiple users using the -u or -A
 parameters.
 
-<!-- @include: include/global-options.inc -->
+<!-- @include: ./global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: include/option-A.inc -->
+<!-- @include: ./option-A.inc -->
 
-<!-- @include: include/option-F-file.inc -->
+<!-- @include: ./option-F-file.inc -->
 
 **-1**
 :   Do one-way synchronization instead of two-way synchronization.
@@ -120,7 +120,7 @@ parameters.
 :   Synchronize all the available namespaces. By default only namespaces
     that don't have explicit location setting are synchronized.
 
-<!-- @include: include/option-no-userdb-lookup.inc -->
+<!-- @include: ./option-no-userdb-lookup.inc -->
 
 **-P**
 :   Run a [[man,doveadm-purge]] for the destination (remote) storage
@@ -131,7 +131,7 @@ parameters.
     system to the destination (remote). This option reverses the flow,
     and will instead pull messages from the remote to the local storage.
 
-<!-- @include: include/option-S-socket.inc -->
+<!-- @include: ./option-S-socket.inc -->
 
 **-T** *secs*
 :   Specify the time in seconds, how long [[man,doveadm]] should wait
@@ -184,7 +184,7 @@ parameters.
 :   Use stateful synchronization. If the previous state is unknown, use
     an empty string. The new state is always printed to standard output.
 
-<!-- @include: include/option-u-user.inc -->
+<!-- @include: ./option-u-user.inc -->
 
 **-x** *mailbox_mask*
 :   Exclude the specified mailbox name/mask. The mask may contain "**?**"
@@ -302,7 +302,7 @@ Once all users have been converted, you can set the default
 *mail_location* to mdbox and remove the per-user mail locations from
 *userdb*.
 
-<!-- @include: include/reporting-bugs.inc -->
+<!-- @include: ./reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/include/doveadm-copy-move.inc
+++ b/docs/core/man/include/doveadm-copy-move.inc
@@ -38,19 +38,19 @@ given *search_query*, into the user's *destination* mailbox.
 In the third form, matching mails will be moved or copied only for
 given *user*(s).
 
-<!-- @include: include/global-options.inc -->
+<!-- @include: ./global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: include/option-A.inc -->
+<!-- @include: ./option-A.inc -->
 
-<!-- @include: include/option-F-file.inc -->
+<!-- @include: ./option-F-file.inc -->
 
-<!-- @include: include/option-no-userdb-lookup.inc -->
+<!-- @include: ./option-no-userdb-lookup.inc -->
 
-<!-- @include: include/option-S-socket.inc -->
+<!-- @include: ./option-S-socket.inc -->
 
-<!-- @include: include/option-u-user.inc -->
+<!-- @include: ./option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -81,7 +81,7 @@ $ doveadm move -u jane Archive/2011/09 mailbox INBOX BEFORE \
       2011-10-01 SINCE 01-Sep-2011
 ```
 
-<!-- @include: include/reporting-bugs.inc -->
+<!-- @include: ./reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/include/global-options-formatter.inc
+++ b/docs/core/man/include/global-options-formatter.inc
@@ -1,4 +1,4 @@
-<!-- @include: include/global-options.inc -->
+<!-- @include: ./global-options.inc -->
 
 **-f** *formatter*
 :   Specifies the *formatter* for formatting the output. Supported

--- a/util/generate_man.js
+++ b/util/generate_man.js
@@ -43,7 +43,7 @@ const doInclude = (content, f) => {
 	return content.replace(includesRE, (m, m1) => {
 		if (!m1.length) return m
 		const inc_f = path.join(path.dirname(f), m1)
-		return doInclude(fs.readFileSync(inc_f, 'utf8'), f)
+		return doInclude(fs.readFileSync(inc_f, 'utf8'), inc_f)
 	})
 }
 


### PR DESCRIPTION
This was breaking rendering in VitePress, as the include paths are relative to the file, not the page rendering the include file

Need to fix man generation utility, with this change, by passing in the filepath of the included file in recursive calls, rather than the original file.