### PR TITLE
Revert "Remove directory from man page includes"

### DIFF
--- a/docs/core/man/doveadm-acl.1.md
+++ b/docs/core/man/doveadm-acl.1.md
@@ -15,21 +15,21 @@ dovecotComponent: core
 The **doveadm acl** *COMMANDS* can be used to execute various Access
 Control List related actions.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 This command uses by default the output formatter **table**.
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -169,7 +169,7 @@ Show the *user*'s current ACL rights for the *mailbox*.
 Set ACL rights to the *mailbox*/*id*. If the *id* already exists, the
 existing rights are replaced.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-altmove.1.md
+++ b/docs/core/man/doveadm-altmove.1.md
@@ -33,24 +33,24 @@ In the third form, the command will be performed for the user contained in the
 In the last form, only matching mails of the given *user*\ (s) will be
 moved to the alternative storage.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
 **-r**
 :   When the **-r** option is given this *command* works the other way
     round. Mails will be moved from the alternative storage back to the
     default mail location.
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -79,7 +79,7 @@ mail_location = mdbox:~/mdbox:ALT=/nfsmount/%h/mdbox
 $ doveadm altmove -u johnd@example.com seen savedbefore 1w<
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-auth.1.md
+++ b/docs/core/man/doveadm-auth.1.md
@@ -15,11 +15,11 @@ dovecotComponent: core
 The **doveadm auth** *COMMANDS* can be used to perform various
 authentication related actions.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## ARGUMENTS
 
@@ -50,7 +50,7 @@ providing their usernames.
     The socket may be located in another directory, when the default
     *base_dir* setting was overridden in */etc/dovecot/dovecot.conf*.
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ### auth lookup
 
@@ -71,7 +71,7 @@ lookup (without authentication) instead of a *userdb* lookup.
 :   When this option and the name of a userdb field is given,
     [[man,doveadm]] will show only the value of the specified field.
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ### auth test
 
@@ -90,7 +90,7 @@ Test authentication for the given user.
 **-A** *sasl_mech*
 :   The SASL mechanism used for the authentication. By default PLAIN is used.
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ### auth login
 
@@ -117,7 +117,7 @@ Test full login for the given user; i.e. performing both passdb lookup (authenti
 **-A** *sasl_mech*
 :   The SASL mechanism used for the authentication. By default PLAIN is used.
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## EXAMPLE
 
@@ -133,7 +133,7 @@ extra fields:
   user=john
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-backup.1.md
+++ b/docs/core/man/doveadm-backup.1.md
@@ -6,4 +6,4 @@ dovecotComponent: core
 
 # doveadm-backup(1) - Dovecot's one-way mailbox synchronization feature
 
-<!-- @include: doveadm-backup-sync.inc -->
+<!-- @include: include/doveadm-backup-sync.inc -->

--- a/docs/core/man/doveadm-compress-connect.1.md
+++ b/docs/core/man/doveadm-compress-connect.1.md
@@ -22,7 +22,7 @@ command **COMPRESS DEFLATE**
 * *host* - the hostname/ip address to connect to
 * *port* - the port to connect to, 143 by default
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-copy.1.md
+++ b/docs/core/man/doveadm-copy.1.md
@@ -6,4 +6,4 @@ dovecotComponent: core
 
 # doveadm-copy(1) - Copy messages matching the given search query into another mailbox
 
-<!-- @include: doveadm-copy-move.inc -->
+<!-- @include: include/doveadm-copy-move.inc -->

--- a/docs/core/man/doveadm-deduplicate.1.md
+++ b/docs/core/man/doveadm-deduplicate.1.md
@@ -20,24 +20,24 @@ messages from the mailbox and keep the oldest.
 
 Deduplication across multiple mailboxes is not supported.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
 **-m**
 :   if the **-m** option is given, [[man,doveadm]] will deduplicate by
     Message-Id header. By default deduplication will be done by message
     GUIDs.
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -71,7 +71,7 @@ a7999e1530739c4bd26d0000ca356bad 18749
 ...
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-dict.1.md
+++ b/docs/core/man/doveadm-dict.1.md
@@ -14,7 +14,7 @@ dovecotComponent: core
 
 **doveadm dict** can be used to query and modify dictionary entries.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 **-u** *user*
 :   The user to use.
@@ -98,7 +98,7 @@ Remove a key from the dictionary.
 *key*
 :   The key to unset.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-dump.1.md
+++ b/docs/core/man/doveadm-dump.1.md
@@ -21,7 +21,7 @@ about index files, see [[link,design_index_format_main].
 files, in human readable format. This is mainly useful for Dovecot
 developers when debugging some problem.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
@@ -96,7 +96,7 @@ Look at the contents of a mailbox's index:
 $ doveadm dump ~/Maildir/.work/
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-exec.1.md
+++ b/docs/core/man/doveadm-exec.1.md
@@ -18,7 +18,7 @@ user could start a pre-authenticated imap session, using the command:
 **doveadm exec imap**. An administrator would use the command
 **doveadm exec imap -u** *username*.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## ARGUMENTS
 
@@ -37,7 +37,7 @@ user's mailbox.
 $ doveadm exec dovecot-lda -d user@example.net -f admin@example.net < ~/stuff/welcome.msg
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 SEE ALSO
 

--- a/docs/core/man/doveadm-expunge.1.md
+++ b/docs/core/man/doveadm-expunge.1.md
@@ -34,22 +34,22 @@ In the third form, the command will be performed for the user contained in the
 In the final form, only matching mails of the given *user* (s) will be
 expunged.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
 **-d**
 :   Delete the mailbox if it is empty after expunging.
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -66,7 +66,7 @@ there more than two weeks ago:
 $ doveadm expunge -u jane.doe@example.org mailbox Spam savedbefore 2w
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-fetch.1.md
+++ b/docs/core/man/doveadm-fetch.1.md
@@ -24,21 +24,21 @@ messages one at a time, see [[man,doveadm-search]].
 
 - Please respect your users' privacy.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 This command uses by default the output formatter **pager**.
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -179,7 +179,7 @@ mailbox: dovecot/pigeonhole/2.0
 date.sent: 2010-03-28 18:41:14 (+0200)
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-flags.1.md
+++ b/docs/core/man/doveadm-flags.1.md
@@ -20,19 +20,19 @@ dovecotComponent: core
 
 This command is used to manipulate flags of messages.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -85,7 +85,7 @@ $ doveadm flags remove -u bob NonJunk mailbox dovecot uid 81563
 $ doveadm flags add -u bob '\Flagged $Forwarded' mailbox dovecot uid 81563
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-force-resync.1.md
+++ b/docs/core/man/doveadm-force-resync.1.md
@@ -24,19 +24,19 @@ situations the **force-resync** command may be helpful. It tries to fix
 all problems. For sdbox and mdbox mailboxes the storage files will be
 also checked.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -52,7 +52,7 @@ Fix bob's INBOX:
 $ doveadm force-resync -u bob INBOX
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-fs.1.md
+++ b/docs/core/man/doveadm-fs.1.md
@@ -17,7 +17,7 @@ storage backend defined in the Dovecot configuration. It allows access
 to the mailbox structure without needing to know details of how the
 storage backend is designed.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 This command uses by default the **table** output formatter.
 
@@ -83,7 +83,7 @@ Store data at the path provided.
 Retrieve files status for the path provided. Currently, only the total
 size (in bytes) of the item is returned.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 SEE ALSO
 

--- a/docs/core/man/doveadm-fts.1.md
+++ b/docs/core/man/doveadm-fts.1.md
@@ -15,22 +15,22 @@ dovecotComponent: core
 The doveadm fts *COMMANDS* can be used to manipulate the Full Text
 Search (FTS) index.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 This command uses by default the output formatter **flow** (without the
 *key*=prefix).
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -113,7 +113,7 @@ Exit codes:
 **2**
 :   The mailbox is not fully consistent
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-help.1.md
+++ b/docs/core/man/doveadm-help.1.md
@@ -20,9 +20,9 @@ With no *command* argument given, **doveadm help** will print:
 When the name of a *command* (or a group) was given, it will show the
 man page for that command.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-import.1.md
+++ b/docs/core/man/doveadm-import.1.md
@@ -36,17 +36,17 @@ In the third form, the command will be performed for the user contained in the
 
 In the final form, the mails will be imported only for given *user* (s).
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
 **-s**
 :   When the **-s** option is present, *dest_parent* and all new
@@ -56,7 +56,7 @@ In the final form, the mails will be imported only for given *user* (s).
 :   When the **-U** option is present, the source box is opened with
     given username.
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -93,7 +93,7 @@ $ doveadm import -u jane.doe@example.org \
       mdbox:~/mdbox-backup "" mailbox INBOX from foo@example.org
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-index.1.md
+++ b/docs/core/man/doveadm-index.1.md
@@ -39,13 +39,13 @@ plugin {
 ```
 :::
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
 **-n** *max_recent*
 :   An integer value, which specifies the maximum number of \\Recent
@@ -54,7 +54,7 @@ plugin {
     This may be useful to avoid unnecessary indexing for large mailboxes
     that are never opened.
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
 **-q**
 :   Queues the indexing to be run by indexer process. Without -q the
@@ -62,9 +62,9 @@ plugin {
     backends can't handle multiple processes updating the indexes
     simultaneously, so -q should usually be used on production.
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -79,7 +79,7 @@ Index bob's INBOX:
 $ doveadm index -u bob INBOX
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-indexer.1.md
+++ b/docs/core/man/doveadm-indexer.1.md
@@ -14,7 +14,7 @@ dovecotComponent: core
 
 **doveadm indexer** can be used to manage the indexer process.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## COMMANDS
 
@@ -53,7 +53,7 @@ List all the queued indexing requests matching *user_mask*. It's possible to
 use wildcards. Requests that are currently processed by indexer-worker are
 not listed; use **doveadm who** instead to see them.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-instance.1.md
+++ b/docs/core/man/doveadm-instance.1.md
@@ -26,7 +26,7 @@ Instances can be named by setting *instance_name* in each instance's
 giving **-i** *instance_name* command line parameter for Dovecot
 binaries (e.g. doveadm).
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## ARGUMENTS
 
@@ -51,7 +51,7 @@ This command lists the seen Dovecot instances.
 
 This command removes the specified instance.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-kick.1.md
+++ b/docs/core/man/doveadm-kick.1.md
@@ -33,7 +33,7 @@ networks range and a matching login name will be disconnected.
 In the last form, all proxy connections to the given destination host
 are disconnected.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
@@ -99,7 +99,7 @@ username                  # service (pids) (ips)
 foo                       1 imap    (8135) (fd95:4eed:38ba::25)
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-log.1.md
+++ b/docs/core/man/doveadm-log.1.md
@@ -22,7 +22,7 @@ The **doveadm log** *commands* are used to locate and reopen the log
 files of [[man,dovecot]]. It's also possible to test the configured
 targets of the *log_path* settings.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## COMMANDS
 
@@ -84,7 +84,7 @@ Error: /var/log/mail.log
 Fatal: /var/log/mail.log
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-mailbox-cryptokey.1.md
+++ b/docs/core/man/doveadm-mailbox-cryptokey.1.md
@@ -19,22 +19,22 @@ active.
 
 **doveadm mailbox cryptokey** can be used to manage user's cryptographic keys.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 **-o** *plugin/mail_crypt_private_password=password*
 :   Dovecot option, needed if you use password protected keys
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## SUBCOMMANDS
 

--- a/docs/core/man/doveadm-mailbox.1.md
+++ b/docs/core/man/doveadm-mailbox.1.md
@@ -14,19 +14,19 @@ dovecotComponent: core
 
 **doveadm mailbox** can be used to query and modify mailboxes.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -376,7 +376,7 @@ $ doveadm mailbox mutf7 ~peter/mail/台北/日本語
 ~peter/mail/&U,BTFw-/&ZeVnLIqe-
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-move.1.md
+++ b/docs/core/man/doveadm-move.1.md
@@ -6,4 +6,4 @@ dovecotComponent: core
 
 # doveadm-move(1) - Move messages matching the given search query into another mailbox
 
-<!-- @include: doveadm-copy-move.inc -->
+<!-- @include: include/doveadm-copy-move.inc -->

--- a/docs/core/man/doveadm-penalty.1.md
+++ b/docs/core/man/doveadm-penalty.1.md
@@ -17,7 +17,7 @@ penalties.
 
 <!-- todo:: (Extend me!/explain it) -->
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
@@ -46,7 +46,7 @@ IP               penalty last_penalty        last_update
 192.0.2.53             3 2010-06-15 15:19:34 15:19:34
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-process-status.1.md
+++ b/docs/core/man/doveadm-process-status.1.md
@@ -36,7 +36,7 @@ containing the following details:
 *last_kill_sent*
 :   timestamp of the latest SIGINT signal sent to the process
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## ARGUMENTS
 
@@ -55,7 +55,7 @@ config 132357 999             6           0          1685365436         0
 anvil  132355 1000            0           1685352908 1685352908         0
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-proxy.1.md
+++ b/docs/core/man/doveadm-proxy.1.md
@@ -17,7 +17,7 @@ dovecotComponent: core
 These commands are aliases to the [[man,doveadm-kick]] and
 [[man,doveadm-who]] commands.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-purge.1.md
+++ b/docs/core/man/doveadm-purge.1.md
@@ -34,22 +34,22 @@ the given *file*.
 
 In the last form, only messages of the given *user* (s) will be purged.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-pw.1.md
+++ b/docs/core/man/doveadm-pw.1.md
@@ -27,7 +27,7 @@ overridden by storing the password with the scheme prefix.
 If you want to use this feature to verify or generate passwords without
 configuring Dovecot first, you can use `doveadm -O pw` to do so.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
@@ -102,7 +102,7 @@ Retype new password:
 {CRAM-MD5}913331d8782236a8ecba7764a63aa27b26437fd40ca878d887f11d81245c2c6b
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-quota.1.md
+++ b/docs/core/man/doveadm-quota.1.md
@@ -31,19 +31,19 @@ In the last form, the command will affect only the matching *user*(s).
 - The **quota get** and **quota recalc** commands are only available
   when the global *mail_plugins* setting contains the **quota** plugin.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## COMMANDS
 
@@ -88,7 +88,7 @@ user                              STORAGE 90099 102400 87
 user                              MESSAGE 20548  30000 68
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-rebuild.1.md
+++ b/docs/core/man/doveadm-rebuild.1.md
@@ -37,22 +37,22 @@ In the third form, the command will be performed for the user contained in the
 In the last form, only matching mails of the given *user* (s) will be
 rebuilt
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 This command uses by default the output formatter **flow** (without the
 *key* = prefix).
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -71,7 +71,7 @@ $ doveadm rebuild attachments -u bob ALL
 3
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-save.1.md
+++ b/docs/core/man/doveadm-save.1.md
@@ -22,19 +22,19 @@ dovecotComponent: core
 scripts and for debugging. Sieve is not invoked for saved messages, but
 quota is enforced.
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 **-m** *mailbox*
 :   Store mail to specified mailbox instead of INBOX.
@@ -55,7 +55,7 @@ quota is enforced.
 $ echo "hello, world" | doveadm save -u testuser@testdomain
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-search-query.7.md
+++ b/docs/core/man/doveadm-search-query.7.md
@@ -305,7 +305,7 @@ is obligatory.
     example: **larger 1M** or **larger 1024k**.
 
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-search.1.md
+++ b/docs/core/man/doveadm-search.1.md
@@ -38,22 +38,22 @@ In the third form, the command will be performed for the user contained in the
 In the last form, only matching mails of the given *user*(s) will be
 searched.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 This command uses by default the output formatter **flow** (without the
 *key*=prefix).
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -86,7 +86,7 @@ $ while read guid uid; do
   done
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-service-status.1.md
+++ b/docs/core/man/doveadm-service-status.1.md
@@ -59,7 +59,7 @@ containing the following details:
 :   the total number of processes forked for the service since the service
     start.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## ARGUMENTS
 
@@ -89,7 +89,7 @@ process_total: 0
 name: fs-server
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-sieve.1.md
+++ b/docs/core/man/doveadm-sieve.1.md
@@ -18,19 +18,19 @@ Dovecot ([[man,dovecot]]).
 
 The **doveadm sieve** commands can be used to manage Sieve filtering.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: include/option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: include/option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: include/option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: include/option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -93,7 +93,7 @@ for execution at delivery.
 
 This command deactivates Sieve processing.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-stats.1.md
+++ b/docs/core/man/doveadm-stats.1.md
@@ -69,7 +69,7 @@ Filter can be
 
 **top** accepts any valid field name to sort along with.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-sync.1.md
+++ b/docs/core/man/doveadm-sync.1.md
@@ -6,4 +6,4 @@ dovecotComponent: core
 
 # doveadm-sync(1) - Dovecot's two-way mailbox synchronization feature
 
-<!-- @include: doveadm-backup-sync.inc -->
+<!-- @include: include/doveadm-backup-sync.inc -->

--- a/docs/core/man/doveadm-user.1.md
+++ b/docs/core/man/doveadm-user.1.md
@@ -28,7 +28,7 @@ userdb {
 }
 ```
 
-<!-- @include: global-options.inc -->
+<!-- @include: include/global-options.inc -->
 
 ## OPTIONS
 
@@ -50,7 +50,7 @@ The socket may be located in another directory, when the default
     *home* or *mail* fields are missing, their defaults are taken from
     configuration file.
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## ARGUMENTS
 
@@ -90,7 +90,7 @@ judy.roe@example.net
 john.doe@example.net
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm-who.1.md
+++ b/docs/core/man/doveadm-who.1.md
@@ -15,7 +15,7 @@ dovecotComponent: core
 The **who** command is used to show which users from which hosts are
 currently connected to which service.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 This command uses by default the output formatter **table**.
 
@@ -79,7 +79,7 @@ james                       1 imap  (30091)       (127.0.0.1)
 jane                        2 imap  (30155 30412) (::1)
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/doveadm.1.md
+++ b/docs/core/man/doveadm.1.md
@@ -23,7 +23,7 @@ manage various parts of Dovecot, as well as access users' mailboxes.
 
 Execute **doveadm help**, for a command usage listing.
 
-<!-- @include: global-options-formatter.inc -->
+<!-- @include: include/global-options-formatter.inc -->
 
 ## COMMANDS
 
@@ -327,7 +327,7 @@ UIDs matching given search query.
 */etc/dovecot/conf.d/90-plugin.conf*
 :   Plugin specific settings.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 
 ## SEE ALSO

--- a/docs/core/man/doveconf.1.md
+++ b/docs/core/man/doveconf.1.md
@@ -142,7 +142,7 @@ $ doveconf dict/quota_clone
 dict/quota_clone = pgsql:/etc/dovecot/dovecot-dict-sql.conf.ext
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/dovecot-lda.1.md
+++ b/docs/core/man/dovecot-lda.1.md
@@ -107,7 +107,7 @@ Options accepted by **dovecot-lda**:
 */etc/dovecot/conf.d/90-quota.conf*
 :   Quota configuration.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/dovecot-sysreport.1.md
+++ b/docs/core/man/dovecot-sysreport.1.md
@@ -40,4 +40,4 @@ core file along with its binary dependencies.
 **-k|-\-keeptemp**
 :   If set, temp files would not be deleted at the end.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->

--- a/docs/core/man/dovecot.1.md
+++ b/docs/core/man/dovecot.1.md
@@ -119,7 +119,7 @@ The *signals* **ALARM** and **PIPE** are ignored.
 */etc/dovecot/conf.d/*.conf*
 :   Configuration files of different services and settings.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/include/doveadm-backup-sync.inc
+++ b/docs/core/man/include/doveadm-backup-sync.inc
@@ -103,13 +103,13 @@ server processes to be running, except when using -u parameter to do a
 dsync can sync either one or multiple users using the -u or -A
 parameters.
 
-<!-- @include: global-options.inc -->
+<!-- @include: ./global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: ./option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: ./option-F-file.inc -->
 
 **-1**
 :   Do one-way synchronization instead of two-way synchronization.
@@ -121,7 +121,7 @@ parameters.
 :   Synchronize all the available namespaces. By default only namespaces
     that don't have explicit location setting are synchronized.
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: ./option-no-userdb-lookup.inc -->
 
 **-P**
 :   Run a [[man,doveadm-purge]] for the destination (remote) storage
@@ -132,7 +132,7 @@ parameters.
     system to the destination (remote). This option reverses the flow,
     and will instead pull messages from the remote to the local storage.
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: ./option-S-socket.inc -->
 
 **-T** *secs*
 :   Specify the time in seconds, how long [[man,doveadm]] should wait
@@ -185,7 +185,7 @@ parameters.
 :   Use stateful synchronization. If the previous state is unknown, use
     an empty string. The new state is always printed to standard output.
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: ./option-u-user.inc -->
 
 **-x** *mailbox_mask*
 :   Exclude the specified mailbox name/mask. The mask may contain "**?**"
@@ -303,7 +303,7 @@ Once all users have been converted, you can set the default
 *mail_location* to mdbox and remove the per-user mail locations from
 *userdb*.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: ./reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/include/doveadm-copy-move.inc
+++ b/docs/core/man/include/doveadm-copy-move.inc
@@ -38,19 +38,19 @@ given *search_query*, into the user's *destination* mailbox.
 In the third form, matching mails will be moved or copied only for
 given *user*(s).
 
-<!-- @include: global-options.inc -->
+<!-- @include: ./global-options.inc -->
 
 ## OPTIONS
 
-<!-- @include: option-A.inc -->
+<!-- @include: ./option-A.inc -->
 
-<!-- @include: option-F-file.inc -->
+<!-- @include: ./option-F-file.inc -->
 
-<!-- @include: option-no-userdb-lookup.inc -->
+<!-- @include: ./option-no-userdb-lookup.inc -->
 
-<!-- @include: option-S-socket.inc -->
+<!-- @include: ./option-S-socket.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: ./option-u-user.inc -->
 
 ## ARGUMENTS
 
@@ -81,7 +81,7 @@ $ doveadm move -u jane Archive/2011/09 mailbox INBOX BEFORE \
       2011-10-01 SINCE 01-Sep-2011
 ```
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: ./reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/include/global-options-formatter.inc
+++ b/docs/core/man/include/global-options-formatter.inc
@@ -1,4 +1,4 @@
-<!-- @include: global-options.inc -->
+<!-- @include: ./global-options.inc -->
 
 **-f** *formatter*
 :   Specifies the *formatter* for formatting the output. Supported

--- a/docs/core/man/pigeonhole.7.md
+++ b/docs/core/man/pigeonhole.7.md
@@ -77,7 +77,7 @@ The following command line tools are available outside of **doveadm**:
 :   Dumps the content of a Sieve binary file for (development) debugging
     purposes.
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/sieve-dump.1.md
+++ b/docs/core/man/sieve-dump.1.md
@@ -48,11 +48,11 @@ compiling the binary.
 :   Produce per-block hexdump output of the whole binary instead of the
     normal human-readable output.
 
-<!-- @include: option-o.inc -->
+<!-- @include: include/option-o.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## ARGUMENTS
 
@@ -86,7 +86,7 @@ compiling the binary.
 :   Sieve interpreter settings (included from Dovecot's main
 :   configuration file)
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/sieve-filter.1.md
+++ b/docs/core/man/sieve-filter.1.md
@@ -83,7 +83,7 @@ course:
     binary. Refer to [[man,sievec]] for more information about Sieve
     compilation.
 
-<!-- @include: option-d.inc -->
+<!-- @include: include/option-d.inc -->
 
 **-D**
 :   Enable Sieve debugging.
@@ -104,7 +104,7 @@ course:
     to the explanation of the *source-mailbox* argument for more
     information on mailbox naming.
 
-<!-- @include: option-o.inc -->
+<!-- @include: include/option-o.inc -->
 
 **-q**\ *output-mailbox*\ **[not implemented yet]**
 :   Store outgoing e-mail into the indicated *output-mailbox*. By
@@ -128,7 +128,7 @@ course:
     Multiple **-s** arguments are allowed and the specified scripts are
     executed sequentially in the order specified at the command line.
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
 **-v**
 :   Produce verbose output during filtering.
@@ -138,7 +138,7 @@ course:
     the messages from the *source-mailbox*, changing their contents, and
     changing the assigned IMAP flags and keywords.
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## ARGUMENTS
 
@@ -247,7 +247,7 @@ FIXME
 :   Sieve interpreter settings (included from Dovecot's main
     configuration file)
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/sieve-test.1.md
+++ b/docs/core/man/sieve-test.1.md
@@ -56,7 +56,7 @@ the execution and evaluation of commands and tests respectively.
 **-D**
 :   Enable Sieve debugging.
 
-<!-- @include: option-d.inc -->
+<!-- @include: include/option-d.inc -->
 
 **-e**
 :   Enables true execution of the set of actions that results from
@@ -86,7 +86,7 @@ the execution and evaluation of commands and tests respectively.
 :   The mailbox where the keep action stores the message. This is "INBOX"
     by default.
 
-<!-- @include: option-o.inc -->
+<!-- @include: include/option-o.inc -->
 
 **-r**\ *recipient-address*
 :   The final envelope recipient address. Some tests and actions will use
@@ -112,9 +112,9 @@ the execution and evaluation of commands and tests respectively.
 :   Configures runtime trace debugging, which is enabled with the **-t**
     option. Refer to the runtime trace debugging section below.
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## ARGUMENTS
 
@@ -221,7 +221,7 @@ logging facility.
 :   Sieve interpreter settings (included from Dovecot's main
     configuration file)
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 

--- a/docs/core/man/sievec.1.md
+++ b/docs/core/man/sievec.1.md
@@ -63,11 +63,11 @@ to find bugs in the compiler that yield corrupt binaries.
 **-D**
 :   Enable Sieve debugging.
 
-<!-- @include: option-o.inc -->
+<!-- @include: include/option-o.inc -->
 
-<!-- @include: option-u-user.inc -->
+<!-- @include: include/option-u-user.inc -->
 
-<!-- @include: option-x.inc -->
+<!-- @include: include/option-x.inc -->
 
 ## ARGUMENTS
 
@@ -128,7 +128,7 @@ to find bugs in the compiler that yield corrupt binaries.
 :   Sieve interpreter settings (included from Dovecot's main
 :   configuration file)
 
-<!-- @include: reporting-bugs.inc -->
+<!-- @include: include/reporting-bugs.inc -->
 
 ## SEE ALSO
 


### PR DESCRIPTION
This reverts commit 91a4f5b5f5588e0e412d74bf13f843a03f3c89d9.

We need the paths for vitepress. Generate_man does includes so that having a path won't cause problems.