### PR TITLE
markdown: Add ability to change text for a Dovecot plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,11 @@ Section is the section number.  It defaults to `1`.
 
 #### Plugin
 
-***Syntax: `[[plugin,plugin_name]]`***
+***Syntax: `[[plugin,plugin_name(,text)]]`***
 
 Links to the plugin page.
+
+If `text` is set, it is used as the link text instead of the plugin name.
 
 #### RFC
 

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -226,6 +226,7 @@ function dovecot_markdown(md, opts) {
 
 		case 'plugin':
 			env.inner = parts[1]
+			env.args = parts[2] ? parts[2] : undefined
 			const plugin = env.inner.replaceAll('-', '_')
 
 			if (!opts.plugins.includes(plugin)) {
@@ -234,8 +235,8 @@ function dovecot_markdown(md, opts) {
 			}
 
 			return '<a href="' +
-				resolveURL('core/plugins/' + plugin + '.html' +
-					(parts[2] ? '#' + parts[2] : ''), opts.base) + '">'
+				resolveURL('core/plugins/' + plugin + '.html', opts.base) +
+					'">'
 
 		case 'removed':
 			env.args = parts[1]
@@ -324,7 +325,7 @@ function dovecot_markdown(md, opts) {
 			return env.inner + '(' + env.args + ')'
 
 		case 'plugin':
-			return env.inner + ' plugin'
+			return env.args ?? (env.inner + ' plugin')
 
 		case 'rfc':
 			return 'RFC ' + env.inner +


### PR DESCRIPTION
GitHub Issue #1017

The code silently was supporting a 2nd argument, that would have been added as an anchor to the URL. However, that kind of linking has been replaced by dovecotlinks functionality.  Additionally, there were already several existing plugin links that was already using the 2nd argument as a "text" replacement, so just change to that usage.