### PR TITLE
npm: Upgrade path-to-regexp to fix high severity vulnerability

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -111,11 +111,11 @@ export async function frontmatterIter(callback) {
 	/* Check for config override file. */
 	const lconf = await loadLocalConf()
 	const spt_conf = lconf?.source_path_translations ??
-		{ 'docs/:path(.*)': ':path' }
+		{ 'docs/:path': ':path' }
 
 	const spt = Object.entries(spt_conf).map(([from, to]) => ({
 		toPath: compile(`/${to}`, { validate: false }),
-		matchUrl: match(from.startsWith('^') ? new RegExp(from) : from)
+		matchUrl: match(from)
 	}))
 
 	for (let f of files) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "core",
       "devDependencies": {
         "@sindresorhus/slugify": "^2.2.1",
         "commander": "^12.1.0",
@@ -15,7 +16,7 @@
         "markdown-it-deflist": "^3.0.0",
         "markdown-it-mathjax3": "^4.3.2",
         "pagefind": "^1.1.1",
-        "path-to-regexp": "^7.1.0",
+        "path-to-regexp": "^8.1.0",
         "pdc": "^0.2.3",
         "remark-definition-list": "^2.0.0",
         "remark-man": "^9.0.0",
@@ -4079,9 +4080,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-7.1.0.tgz",
-      "integrity": "sha512-ZToe+MbUF4lBqk6dV8GKot4DKfzrxXsplOddH8zN3YK+qw9/McvP7+4ICjZvOne0jQhN4eJwHsX6tT0Ns19fvw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
       "dev": true,
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "pagefind": "^1.1.1",
-    "path-to-regexp": "^7.1.0",
+    "path-to-regexp": "^8.1.0",
     "pdc": "^0.2.3",
     "remark-definition-list": "^2.0.0",
     "remark-man": "^9.0.0",


### PR DESCRIPTION
API breaking, so requires code changes