### PR TITLE
data/lua: Drop _msecs from http client settings

### DIFF
--- a/components/LuaFunctionComponent.vue
+++ b/components/LuaFunctionComponent.vue
@@ -78,7 +78,7 @@ function buildFunctionSignature(k, v) {
          <td><code>{{ k2 }}</code></td>
          <td><em>{{ v2.type }}</em></td>
          <td>
-          <span v-html="v2.text" />
+          <div class="lua-function-description" v-html="v2.text" />
           <span v-if="v2.default">(Default: <code>{{ v2.default }}</code>)</span>
          </td>
         </tr>
@@ -103,5 +103,8 @@ function buildFunctionSignature(k, v) {
   border-top: 1px solid #e2e2e3;
   margin: 15px auto;
   width: 75%;
+}
+.lua-function-description :deep(p) {
+  margin: 0;
 }
 </style>

--- a/data/lua.js
+++ b/data/lua.js
@@ -136,22 +136,16 @@ are not restricted.`
 				text: `Never automatically retry requests.`
 			},
 			connect_backoff_time: {
-				default: '100 msec',
+				dovecot_setting: 'http_client_connect_backoff_time',
 				hash_arg: true,
-				type: 'int',
-				text: `Initial backoff time; doubled at each connection failure.`
 			},
 			connect_backoff_max_time: {
-				default: '60000 msec',
+				dovecot_setting: 'http_client_connect_backoff_max_time',
 				hash_arg: true,
-				type: 'int',
-				text: `Maximum backoff time.`
 			},
 			connect_timeout: {
-				default: '<request_timeout>',
+				dovecot_setting: 'http_client_connect_timeout',
 				hash_arg: true,
-				type: 'int',
-				text: `Max time to wait for \`connect()\` (and SSL handshake) to finish before retrying.`
 			},
 			event_parent: {
 				hash_arg: true,
@@ -159,85 +153,99 @@ are not restricted.`
 				text: `Parent event to use.`
 			},
 			max_attempts: {
-				default: '1',
+				dovecot_setting: 'http_client_request_max_attempts',
 				hash_arg: true,
-				type: 'int',
-				text: `Maximum number of attempts for a request.`
 			},
 			max_auto_retry_delay: {
+				dovecot_setting: 'http_client_max_auto_retry_delay',
 				hash_arg: true,
-				type: 'int',
-				text: `
-Maximum acceptable delay in seconds for automatically retrying/redirecting
-requests.
-
-If a server sends a response with a \`Retry-After\` header that causes a
-delay longer than this, the request is not automatically retried and
-the response is returned.`
 			},
 			max_connect_attempts: {
+				dovecot_setting: 'http_client_max_connect_attempts',
 				hash_arg: true,
-				type: 'int',
-				text: `
-Maximum number of connection attempts to a host before all associated
-requests fail.
-
-If > 1, the maximum will be enforced across all IPs for that host, meaning
-that IPs may be tried more than once eventually if the number of IPs is
-smaller than the specified maximum attempts. If the number of IPs is
-higher than the maximum attempts, not all IPs are tried.
-
-If <= 1, all IPs are tried at most once.`
 			},
 			max_idle_time: {
+				dovecot_setting: 'http_client_max_idle_time',
 				hash_arg: true,
-				type: 'int',
-				text: `
-Maximum time a connection will idle before disconnecting.
-
-If parallel connections are idle, the duplicates will end earlier based on
-how many idle connections exist to that same service.`
 			},
 			max_redirects: {
-				default: '0; redirects refused',
+				dovecot_setting: 'http_client_request_max_redirects',
 				hash_arg: true,
-				type: 'int',
-				text: `Maximum number of redirects for a request.`
 			},
 			proxy_url: {
+				dovecot_setting: 'http_client_proxy_url',
 				hash_arg: true,
-				type: 'string',
 				text: `Proxy URL to use, can include username and password.`
 			},
 			request_absolute_timeout: {
-				default: '0; no timeout',
+				dovecot_setting: 'http_client_request_absolute_timeout',
 				hash_arg: true,
-				type: 'int',
-				text: `Max total time to wait for HTTP request to finish, including retries and everything else.`
 			},
 			request_timeout: {
-				default: '60000 msec',
+				dovecot_setting: 'http_client_request_timeout',
 				hash_arg: true,
-				type: 'int',
-				text: `Max time to wait for HTTP response before retrying.`
 			},
 			soft_connect_timeout: {
-				default: '0; wait until current connection attempt finishes',
+				dovecot_setting: 'http_client_soft_connect_timeout',
 				hash_arg: true,
-				type: 'int',
-				text: `Time to wait for \`connect()\` (and SSL handshake) to finish for the first connection before trying the next IP in parallel.`
+			},
+			ssl_cipher_list: {
+				dovecot_setting: 'ssl_cipher_list',
+				hash_arg: true
+			},
+			ssl_cipher_suites: {
+				dovecot_setting: 'ssl_cipher_suites',
+				hash_arg: true
+			},
+			ssl_client_ca_dir: {
+				dovecot_setting: 'ssl_client_ca_dir',
+				hash_arg: true
+			},
+			ssl_client_ca_file: {
+				dovecot_setting: 'ssl_client_ca_file',
+				hash_arg: true
+			},
+			ssl_client_cert_file: {
+				dovecot_setting: 'ssl_client_cert_file',
+				hash_arg: true
+			},
+			ssl_client_key_file: {
+				dovecot_setting: 'ssl_client_key_file',
+				hash_arg: true
+			},
+			ssl_client_key_password: {
+				dovecot_setting: 'ssl_client_key_password',
+				hash_arg: true
+			},
+			ssl_crypto_device: {
+				dovecot_setting: 'ssl_crypto_device',
+				hash_arg: true
+			},
+			ssl_curve_list: {
+				dovecot_setting: 'ssl_curve_list',
+				hash_arg: true
+			},
+			ssl_client_require_valid_cert: {
+				dovecot_setting: 'ssl_client_require_valid_cert',
+				hash_arg: true
+			},
+			ssl_min_protocol: {
+				dovecot_setting: 'ssl_min_protocol',
+				hash_arg: true
+			},
+			ssl_options: {
+				dovecot_setting: 'ssl_options',
+				hash_arg: true
 			},
 			rawlog_dir: {
+				dovecot_setting: 'http_client_rawlog_dir',
 				hash_arg: true,
-				type: 'string',
-				text: `Directory for writing raw log data for debugging purposes. Must be writable by the process creating this log.`
 			},
 			user_agent: {
-				default: '<none>',
+				dovecot_setting: 'http_client_user_agent',
 				hash_arg: true,
-				type: 'string',
-				text: `\`User-Agent:\` header.`
 			},
+
 		},
 		return: 'An http_client object.',
 		tags: [ 'dovecot.http' ],

--- a/data/lua.js
+++ b/data/lua.js
@@ -9,6 +9,11 @@ export const lua_functions = [
 		// List of function arguments
 		args: {
 			text: {
+				// If this argument is set, the 'text (w/default)' and
+				// 'values' information from the Dovecot setting is used if it
+				// does NOT otherwise exist in this config.
+				// dovecot_setting: 'dovecot_setting_name',
+
 				// If true, this argument appears inside a Lua hash table
 				// instead of as a standalone argument.
 				// hash_arg: false,

--- a/data/lua.js
+++ b/data/lua.js
@@ -130,20 +130,20 @@ are not restricted.`
 				type: 'boolean',
 				text: `Never automatically retry requests.`
 			},
-			connect_backoff_time_msecs: {
+			connect_backoff_time: {
 				default: '100 msec',
 				hash_arg: true,
 				type: 'int',
 				text: `Initial backoff time; doubled at each connection failure.`
 			},
-			connect_backoff_max_time_msecs: {
+			connect_backoff_max_time: {
 				default: '60000 msec',
 				hash_arg: true,
 				type: 'int',
 				text: `Maximum backoff time.`
 			},
-			connect_timeout_msecs: {
-				default: '<request_timeout_msecs>',
+			connect_timeout: {
+				default: '<request_timeout>',
 				hash_arg: true,
 				type: 'int',
 				text: `Max time to wait for \`connect()\` (and SSL handshake) to finish before retrying.`
@@ -159,7 +159,7 @@ are not restricted.`
 				type: 'int',
 				text: `Maximum number of attempts for a request.`
 			},
-			max_auto_retry_delay_secs: {
+			max_auto_retry_delay: {
 				hash_arg: true,
 				type: 'int',
 				text: `
@@ -184,7 +184,7 @@ higher than the maximum attempts, not all IPs are tried.
 
 If <= 1, all IPs are tried at most once.`
 			},
-			max_idle_time_msecs: {
+			max_idle_time: {
 				hash_arg: true,
 				type: 'int',
 				text: `
@@ -204,19 +204,19 @@ how many idle connections exist to that same service.`
 				type: 'string',
 				text: `Proxy URL to use, can include username and password.`
 			},
-			request_absolute_timeout_msecs: {
+			request_absolute_timeout: {
 				default: '0; no timeout',
 				hash_arg: true,
 				type: 'int',
 				text: `Max total time to wait for HTTP request to finish, including retries and everything else.`
 			},
-			request_timeout_msecs: {
+			request_timeout: {
 				default: '60000 msec',
 				hash_arg: true,
 				type: 'int',
 				text: `Max time to wait for HTTP response before retrying.`
 			},
-			soft_connect_timeout_msecs: {
+			soft_connect_timeout: {
 				default: '0; wait until current connection attempt finishes',
 				hash_arg: true,
 				type: 'int',

--- a/data/settings.js
+++ b/data/settings.js
@@ -5660,7 +5660,11 @@ Username for HTTP proxy.`
 			settings_http_client_settings_added: false,
 		},
 		text: `
-Directory for writing raw log data for debugging purposes.`
+Directory for writing raw log data for debugging purposes.
+
+::: warning
+Must be writable by the process creating this log.
+:::`
 	},
 
 	http_client_read_request_max_attempts: {

--- a/lib/data/lua.data.js
+++ b/lib/data/lua.data.js
@@ -22,12 +22,32 @@ async function normalizeLuaConstants(lua) {
 
 async function normalizeLuaFunctions(lua) {
 	const md = await getVitepressMd()
+	let set = false
 	const out = {}
 
 	for (const v of lua.values()) {
 		if (v.args) {
 			for (const [k2, v2] of Object.entries(v.args)) {
-				v2.text = md.renderInline(v2.text)
+				/* Merge information from Dovecot settings. */
+				if (v2.dovecot_setting) {
+					if (!set) {
+						set = structuredClone(loadData('settings').settings)
+					}
+
+					if (!v2.type) {
+						v2.type = set[v2.dovecot_setting].values?.label
+					}
+
+					if (!v2.text) {
+						v2.text = set[v2.dovecot_setting].text.trim()
+					}
+
+					if (v2.default === undefined) {
+						v2.default = set[v2.dovecot_setting].default
+					}
+				}
+
+				v2.text = md.render(v2.text)
 			}
 		}
 


### PR DESCRIPTION
They are now parsed via settings parser, which does not have msecs suffix.

JIRA: DOV-6912