### PR TITLE
utility.js: Make loadData() a sync function

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -131,7 +131,7 @@ export default defineConfig({
 	},
 
 	markdown: {
-		config: async (md) => await dovecotMdExtend(md),
+		config: (md) => dovecotMdExtend(md),
 		image: {
 			lazyLoading: true,
 		},

--- a/lib/data/doveadm.data.js
+++ b/lib/data/doveadm.data.js
@@ -150,7 +150,7 @@ async function normalizeDoveadm(doveadm) {
 export default addWatchPaths({
 	async load() {
 		return await normalizeDoveadm(
-			structuredClone((await loadData('doveadm')).doveadm)
+			structuredClone(loadData('doveadm').doveadm)
 		)
 	}
 })

--- a/lib/data/event_categories.data.js
+++ b/lib/data/event_categories.data.js
@@ -14,7 +14,7 @@ async function normalizeEventCategories(categories) {
 export default addWatchPaths({
 	async load() {
 		return await normalizeEventCategories(
-			structuredClone((await loadData('event_categories')).categories)
+			structuredClone(loadData('event_categories').categories)
 		)
 	}
 })

--- a/lib/data/event_reasons.data.js
+++ b/lib/data/event_reasons.data.js
@@ -14,7 +14,7 @@ async function normalizeEventReasons(reasons) {
 export default addWatchPaths({
 	async load() {
 		return await normalizeEventReasons(
-			structuredClone((await loadData('event_reasons')).reasons)
+			structuredClone(loadData('event_reasons').reasons)
 		)
 	}
 })

--- a/lib/data/events.data.js
+++ b/lib/data/events.data.js
@@ -126,7 +126,7 @@ async function normalizeEvents(events, global_inherits, inherits) {
 
 export default addWatchPaths({
 	async load() {
-		const data = await loadData('events')
+		const data = loadData('events')
 		return await normalizeEvents(
 			structuredClone(data.events),
 			structuredClone(data.global_inherits),

--- a/lib/data/lua.data.js
+++ b/lib/data/lua.data.js
@@ -64,7 +64,7 @@ async function normalizeLuaVariables(lua) {
 
 export default addWatchPaths({
 	async load() {
-		const data = await(loadData('lua'))
+		const data = loadData('lua')
 
 		return {
 			constants: await normalizeLuaConstants(data.lua_constants),

--- a/lib/data/settings.data.js
+++ b/lib/data/settings.data.js
@@ -72,7 +72,7 @@ async function normalizeSettings(settings) {
 export default addWatchPaths({
 	async load() {
 		return await normalizeSettings(
-			structuredClone((await loadData('settings')).settings)
+			structuredClone(loadData('settings').settings)
 		)
 	}
 })

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -5,8 +5,7 @@ import path from 'path'
 import { createMarkdownRenderer } from 'vitepress'
 import { dovecotSetting, frontmatterIter, loadData } from './utility.js'
 
-let md_conf = null
-export async function dovecotMdExtend(md) {
+export function dovecotMdExtend(md) {
 	md.use(containerPlugin, 'todo', {
 		render: function(tokens, idx) {
 			if (tokens[idx].nesting === 1) {
@@ -17,18 +16,7 @@ export async function dovecotMdExtend(md) {
 		}
 	})
 	md.use(deflistPlugin)
-
-	if (md_conf === null) {
-		md_conf = {
-			base: globalThis.VITEPRESS_CONFIG.site.base,
-			doveadm: (await loadData('doveadm')).doveadm,
-			events: (await loadData('events')).events,
-			linkoverrides: (await loadData('links_overrides')).links_overrides,
-			settings: (await loadData('settings')).settings,
-			updates: (await loadData('updates')).updates
-		}
-	}
-	md.use(dovecot_markdown, md_conf)
+	md.use(dovecot_markdown)
 
 	return md
 }
@@ -38,7 +26,7 @@ export async function getVitepressMd() {
 	if (vitepress_md === null) {
 		const config = globalThis.VITEPRESS_CONFIG
 
-		vitepress_md = await dovecotMdExtend(await createMarkdownRenderer(
+		vitepress_md = dovecotMdExtend(await createMarkdownRenderer(
 			config.srcDir,
 			config.markdown,
 			config.site.base,
@@ -52,7 +40,7 @@ export async function getVitepressMd() {
 /* This is a dovecot markdown extension to support the "[[...]]" syntax.
  * Much of this is copied from existing markdown-it plugins. See, e.g.,
  * https://github.com/markdown-it/markdown-it-sub/blob/master/index.mjs */
-function dovecot_markdown(md, opts) {
+function dovecot_markdown(md) {
 	function process_brackets(state, silent) {
 		const max = state.posMax
 		const start = state.pos
@@ -142,6 +130,8 @@ function dovecot_markdown(md, opts) {
 			let page = mode
 			switch (mode) {
 			case 'doveadm':
+				initDoveadm()
+
 				if (!opts.doveadm[env.inner]) {
 					if (!Object.values(opts.doveadm).find((x) => (x.man == 'doveadm-' + env.inner))) {
 						handle_error('doveadm link missing: ' + env.inner)
@@ -151,6 +141,8 @@ function dovecot_markdown(md, opts) {
 				break
 
 			case 'event':
+				initEvents()
+
 				if (!opts.events[env.inner]) {
 					handle_error('event link missing: ' + env.inner)
 					return '<code><a>'
@@ -160,6 +152,8 @@ function dovecot_markdown(md, opts) {
 
 			case 'setting':
 			case 'setting_text':
+				initSettings()
+
 				/* Settings names can have brackets, so we need to unescape
 				 * input for purposes of searching settings keys. */
 				const search_str = env.inner.replaceAll('&gt;', '>')
@@ -293,6 +287,8 @@ function dovecot_markdown(md, opts) {
 		case 'changed':
 		case 'deprecated':
 		case 'removed':
+			initUpdates()
+
 			if (!opts.updates[env.args]) {
 				handle_error('Missing updates entry for: ' + env.args)
 				return env.args
@@ -373,6 +369,12 @@ function dovecot_markdown(md, opts) {
 		console.error(msg)
 	}
 
+	function initDoveadm() {
+		if (!opts.doveadm) {
+			opts.doveadm = loadData('doveadm').doveadm
+		}
+	}
+
 	function initDovecotLinks() {
 		if (opts.dovecotlinks) {
 			return
@@ -406,7 +408,15 @@ function dovecot_markdown(md, opts) {
 			}
 		})
 
-		opts.dovecotlinks = { ...links, ...opts.linkoverrides }
+		opts.dovecotlinks = {
+			...links, ...(loadData('links_overrides').links_overrides)
+		}
+	}
+
+	function initEvents() {
+		if (!opts.events) {
+			opts.events = loadData('events').events
+		}
 	}
 
 	function initManFiles() {
@@ -434,6 +444,18 @@ function dovecot_markdown(md, opts) {
 		}
 	}
 
+	function initSettings() {
+		if (!opts.settings) {
+			opts.settings = loadData('settings').settings
+		}
+	}
+
+	function initUpdates() {
+		if (!opts.updates) {
+			opts.updates = loadData('updates').updates
+		}
+	}
+
 	function resolveURL(url) {
 		if (!('url_rewrite' in opts)) {
 			opts.url_rewrite = dovecotSetting('url_rewrite')
@@ -443,6 +465,10 @@ function dovecot_markdown(md, opts) {
 			(opts.base.endsWith('/') ? opts.base.slice(0, -1) : opts.base) +
 			'/' + url
 		return (opts.url_rewrite) ? opts.url_rewrite(new_url) : new_url
+	}
+
+	const opts = {
+		base: globalThis.VITEPRESS_CONFIG.site.base
 	}
 
 	md.inline.ruler.after('emphasis', 'dovecot_brackets', process_brackets)

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -3,6 +3,7 @@
 import fg from 'fast-glob'
 import fs from 'fs'
 import matter from 'gray-matter'
+import importSync from 'import-sync'
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -26,12 +27,12 @@ export function normalizeArrayData(data, keys) {
 	return data
 }
 
-export async function loadData(id) {
+export function loadData(id) {
 	const path = globalThis.VITEPRESS_CONFIG.userConfig.themeConfig.dovecot?.data_paths?.[id]
 		?? ('../data/' + id + '.js')
 
 	try {
-		return await import(__dirname + '/' + path)
+		return importSync(__dirname + '/' + path)
 	} catch (e) {
 		throw new Error('Unable to import module (' + __dirname + '/' +
 			path + '):' + e)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "dayjs": "^1.11.13",
         "fast-glob": "^3.3.2",
         "git-commit-info": "^2.0.2",
+        "import-sync": "^2.2.2",
         "markdown-it-container": "^4.0.0",
         "markdown-it-deflist": "^3.0.0",
         "markdown-it-mathjax3": "^4.3.2",
@@ -797,6 +798,15 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@httptoolkit/esm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/esm/-/esm-3.3.0.tgz",
+      "integrity": "sha512-gS+TH14750cveYP5p2q/oLyjVV5+qRFZMOpsPzK1KrgacqKc6RLDmt3ioGaMjsn1aianQbROkl4QXDJmO5swPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2886,6 +2896,15 @@
       "dev": true,
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/import-sync": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/import-sync/-/import-sync-2.2.2.tgz",
+      "integrity": "sha512-MQ+8aB1LZu0dHqTmpkOJ5DLCqQNVNqbMrH/S9nvHChUSMsAlX6R3ydQhX3R5/YfCU6+qU3cbASiX59hJisMKgg==",
+      "dev": true,
+      "dependencies": {
+        "@httptoolkit/esm": "^3.3.0"
       }
     },
     "node_modules/inherits": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dayjs": "^1.11.13",
     "fast-glob": "^3.3.2",
     "git-commit-info": "^2.0.2",
+    "import-sync": "^2.2.2",
     "markdown-it-container": "^4.0.0",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-mathjax3": "^4.3.2",


### PR DESCRIPTION
We always want loadData() to be a blocking call, as we use that code to read the data JS files so that we can do further processing.

However, since data JS paths are dynamic, we must use import() which is required to be an async call.

For bootstrapping purposes, this means there is no way to block markdown processing to begin before the Dovecot markdown plugin is ready. This is because markdown-it code MUST NOT use async code, so we need to load all the data (via loadData()) before it can be initialized. Dovecot markdown code also requires VitePress paths to be available in global config object, so the only place we can realistically add the Dovecot markdown processing is via the "config" markdown option. Unfortunately, the internal VitePress code does not call this function with await, so there is simply no way to block processing via this mechanism.

Solution- the import-sync nodejs package allows import behavior to be done synchronously.

This allows us to no longer need to pre-configure the dovecot markdown plugin, as the loadData() calls can now be called on-demand inside of the plugin. Thus, we can guarantee that the Dovecot markdown plugin is initialized at the time the first page is processed by VitePress now.