### PR TITLE
doveadm: Simplify doveadm response display

### DIFF
--- a/components/DoveadmComponent.vue
+++ b/components/DoveadmComponent.vue
@@ -49,7 +49,7 @@ function httpClick(k) {
     <a class="header-anchor" :href="'#' + k"></a>
    </h3>
 
-   <table v-if="v.man_link || v.response || v.added || v.changed || v.deprecated || v.removed">
+   <table v-if="v.man_link || v.added || v.changed || v.deprecated || v.removed">
     <tbody>
      <tr v-if="v.man_link">
       <th style="text-align: right;">Man Page</th>
@@ -79,28 +79,6 @@ function httpClick(k) {
        </ul>
       </td>
     </tr>
-
-     <tr v-if="v.response">
-      <th style="text-align: right;">Response Values</th>
-      <td>
-       <table>
-        <thead>
-         <tr>
-          <th>Key</th>
-          <th>Type</th>
-          <th>Description</th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr v-for="elem in v.response">
-          <td><code>{{ elem.key }}</code></td>
-          <td v-html="elem.type" />
-          <td v-html="elem.text" />
-         </tr>
-        </tbody>
-       </table>
-      </td>
-     </tr>
     </tbody>
    </table>
 

--- a/components/DoveadmHttpApiComponent.vue
+++ b/components/DoveadmHttpApiComponent.vue
@@ -21,21 +21,10 @@ const jsonReq =
 	]
 ]
 
-const resp = {}
-if (d.response) {
-	for (let elem of d.response) {
-		resp[elem.key] = elem.example
-	}
-}
+const jsonResp = d.response?.example
+	? [ [ "doveadmResponse", [ d.response.example ], "tag1" ] ]
+	: null
 
-const jsonResp =
-[
-	[
-		"doveadmResponse",
-		[ resp ],
-		"tag1"
-	]
-]
 </script>
 
 <template>
@@ -105,10 +94,12 @@ const jsonResp =
    <pre><code>wget --header="Content-Type: application/json" --user=doveadm --password=password --auth-no-challenge --post-data='{{ JSON.stringify(jsonReq) }}' --output-document - http://example.com:8080/doveadm/v1</code></pre>
   </div>
 
-  <template v-if="d.response?.length">
+  <template v-if="d.response">
    <p class="custom-block-title">Example Server Response</p>
 
-   <div class="language- vp-adaptive-theme">
+   <div v-html="d.response.text" />
+
+   <div class="language- vp-adaptive-theme" v-id="jsonResp">
     <button class="copy" title="Copy" />
     <span class="lang"></span>
      <pre><code>{{ JSON.stringify(jsonResp, null, 4) }}</code></pre>

--- a/data/doveadm.js
+++ b/data/doveadm.js
@@ -2273,6 +2273,37 @@ returned.`,
 				text: `UID -or- IP Address mask.`,
 			},
 		},
+		response: {
+			example: [
+				{
+					username: "foo",
+					connections: "1",
+					service: "imap",
+					pid: "(47)",
+					ip: "(10.0.2.100)"
+				}
+			],
+			text: `
+Returns an array of objects.
+
+If \`separate-connections\` is \`false\`, each object represents a single
+username/service combination, and the \`pid\` and \`ip\` fields will include
+all entries for that combination.
+
+If \`separate-connections\` is \`true\`, each object will contain a single
+connection.
+
+Object fields:
+
+| Key | Description |
+| --- | ----------- |
+| \`connections\` | The total number of connections for the user. This is only returned if \`separate-connections\` is \`false\`. |
+| \`ip\` | IP addresses where the user's connections are originating. |
+| \`pid\` | Process IDs of the session. |
+| \`service\` | The Dovecot service. |
+| \`username\` | Username |
+`
+		},
 		man: 'doveadm-who',
 		text: `Show who is logged into the Dovecot server.`,
 	},

--- a/data/doveadm.js
+++ b/data/doveadm.js
@@ -2,8 +2,7 @@
 import { doveadm_arg_types,
 		 doveadm_args_query,
 		 doveadm_args_usermask,
-		 doveadm_flag_types,
-		 doveadm_response_types } from '../lib/doveadm.js'
+		 doveadm_flag_types } from '../lib/doveadm.js'
 
 export const doveadm = {
 
@@ -52,20 +51,21 @@ export const doveadm = {
 		// deprecated: {},
 		// removed: {},
 
-		// Response data.
-		// KEY = identifier
+		// Response data. (HTTP API)
+		//
+		// Since doveadm responses are so variable, it is difficult to create
+		// an abstracted system to document the format.
+		//
+		// Thus, (for now) simply provide a place to describe HTTP API
+		// responses.
 		// response: {
-		//     key: {
-		//         // An example value to be used in documentation.
-		//         example: 0,
+		//     // This is the JSON data returned from the server. Do NOT
+		//     // include the enclosing array, as this will be added
+		//     // automatically when displaying.
+		//     example: {},
 		//
-		//         // The description of the response data type.
-		//         // Rendered w/Markdown.
-		//         text: `Description`,
-		//
-		//         // The response data type
-		//         type: doveadm_response_types.INTEGER,
-		//     }
+		//     // A description of the response. Rendered w/Markdown.
+		//     text: ``,
 		// },
 
 		// What doveadm flags does this command support (bit field)
@@ -252,10 +252,14 @@ Applicable to [[link,mdbox]] and [[link,sdbox]] mailbox formats only.
 			},
 		},
 		response: {
-			entries: {
-				type: doveadm_response_types.INTEGER,
-				text: `The number of cache entries flushed.`
+			example: {
+				entries: 1
 			},
+			text: `
+| Key | Description |
+| --- | ----------- |
+| \`entries\` | The number of cache entries flushed. |
+`
 		},
 		man: 'doveadm-auth',
 		text: `Flush authentication cache.`,
@@ -1372,7 +1376,7 @@ to secure it.
 				text: `Mailbox mask.`
 			},
 		},
-		response: {},
+		response: null,
 		flags: doveadm_flag_types.USER,
 		plugin: 'mail-crypt',
 		man: 'doveadm-mailbox-cryptokey',
@@ -1392,7 +1396,7 @@ to secure it.
 				text: `Mailbox mask.`
 			},
 		},
-		response: {},
+		response: null,
 		flags: doveadm_flag_types.USER,
 		plugin: 'mail-crypt',
 		man: 'doveadm-mailbox-cryptokey',
@@ -1427,7 +1431,7 @@ to secure it.
 				text: `Old password.`
 			},
 		},
-		response: {},
+		response: null,
 		flags: doveadm_flag_types.USER,
 		plugin: 'mail-crypt',
 		man: 'doveadm-mailbox-cryptokey',

--- a/lib/data/doveadm.data.js
+++ b/lib/data/doveadm.data.js
@@ -1,4 +1,4 @@
-import { doveadm_arg_types, doveadm_flag_types, doveadm_response_types, getDoveadmCmdLine } from '../doveadm.js'
+import { doveadm_arg_types, doveadm_flag_types, getDoveadmCmdLine } from '../doveadm.js'
 import { getVitepressMd } from '../markdown.js'
 import { addWatchPaths, loadData, normalizeArrayData } from '../utility.js'
 import camelCase from 'camelcase'
@@ -53,15 +53,6 @@ function typeToString(type) {
 	}
 }
 
-function responseTypeLookup(type) {
-	switch (type) {
-	case doveadm_response_types.INTEGER:
-		return [ 'integer', 1 ]
-	case doveadm_response_types.STRING:
-		return [ 'string', 'example' ]
-	}
-}
-
 function argToHttpParam(arg) {
 	return arg.split('-').reduce((s, c) =>
 		s + (c.charAt(0).toUpperCase() + c.slice(1)))
@@ -108,19 +99,10 @@ async function normalizeDoveadm(doveadm) {
 
 		/* Response values. */
 		if (v.response) {
-			const response = []
-			for (const [k2, v2] of Object.entries(v.response)) {
-				var rtl = responseTypeLookup(v2.type)
-				response.push({
-					example: v2.example ?? rtl[1],
-					key: k2,
-					type: rtl[0],
-					text: v2.text ? md.renderInline(String(v2.text)) : null
-				})
+			if (v.response.text) {
+				v.response.text = md.render(String(v.response.text))
 			}
-			v.response = response
-		}
-		if (!v.response || !v.response.length) {
+		} else {
 			delete v['response']
 		}
 

--- a/lib/doveadm.js
+++ b/lib/doveadm.js
@@ -16,12 +16,6 @@ export const doveadm_flag_types = {
 	USERMASK:		4,
 }
 
-/* List of Doveadm response value types. */
-export const doveadm_response_types = {
-	INTEGER:	1,
-	STRING:		2,
-}
-
 export const doveadm_args_query = {
 	//example: ['mailbox', 'INBOX/myfoldertoo', 'savedbefore', 'since', '30d'],
 	positional: true,


### PR DESCRIPTION
Doveadm responses are so variable, that creating an abstract system for documenting would be extremely difficult.

To simplify (for now), do the following:

- Only worry about HTTP API responses
- Allow for free-form description of response info
- Allow for markdown enabled description of the response