### PR TITLE
npm: Add name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "dovecot-ce-documentation",
   "devDependencies": {
     "@sindresorhus/slugify": "^2.2.1",
     "camelcase": "^8.0.0",


### PR DESCRIPTION
This is needed for some npm-like tools (e.g. bun) for some actions