### PR TITLE
DOV-7024: Improve dcrypt design documentation

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -5,6 +5,7 @@ addflag
 addprinc
 ADDRESULT
 ADH
+Adleman
 Aildir
 allbackups
 alloconly
@@ -122,6 +123,7 @@ dcrypt
 DDTHH
 debian
 debuginfo
+decapsulated
 deeplinks
 defaultdelivery
 deinitialization
@@ -327,6 +329,7 @@ kde
 kdump
 keeptemp
 Kek
+kem
 keychain
 keyid
 keypair
@@ -412,7 +415,7 @@ lsearch
 lucene
 lugog
 lwq
-maclen
+macl
 madboa
 mailauth
 mailboxdir
@@ -661,6 +664,7 @@ restorecon
 resyncing
 rfcs
 RHu
+Rivest
 roundcube
 roundrobin
 rpa

--- a/docs/core/design/dcrypt.md
+++ b/docs/core/design/dcrypt.md
@@ -118,26 +118,30 @@ either HMAC based or AEAD based system is used when requested.
 File format 2 is described below
 
 ```
-000 - 008 CRYPTED\x03\x07 (MAGIC)
-009 - 009 \x02 (VERSION FIELD, 2)
-010 - 013 MSB flags
-014 - 017 MSB total header length (starting from 000)
-018 - cod cipher oid in DER format
-cod - mod MAC algorithm oid in DER format
-mod - +4  MSB PBKDF2 rounds
-+5  - +8  MSB length of key data
-+9  - +9  number of key blocks
+----- header -----
+000  - 008  CRYPTED\x03\x07 (MAGIC)
+009  - 009  \x02 (VERSION FIELD, 2)
+010  - 013  MSB flags
+014  - 017  MSB total header length (starting from 000)
+018  - cod  cipher oid in DER format
+cod  - mod  MAC algorithm oid in DER format
+mod  - +4   MSB PBKDF2 rounds
++5   - +8   MSB length of key data
++9   - +9   number of key blocks
 ----- key block -----
-+10 - +10  key type (1 = RSA, 2 = ECC)
-+11 - +43 public key id (SHA256 of public key in DER format, point compressed)
-+44 - +48 MSB length of ephemeral key
-+49 - epk ephemeral key
-epk - +4  MSB length of encryption key
-+4  - ek  encrypted key[+ TAG when AEAD used]
++10  - +10  key type (1 = RSA, 2 = EC)
++11  - +43  public key id (SHA256 of public key in DER format, point compressed)
++44  - +48  MSB length of ephemeral key
++49  - epk  ephemeral key
+epk  - +4   MSB length of encryption key
++4   - ek   encrypted key[+ TAG when AEAD used]
+ek   - +4   MSB length of checksum
++4   - chk  checksum of the payload
 ----- end of key block (this can then repeat) -----
-eokb - +4  MSB length of encryption key hash
-+4 - ekh  encryption key hash
-ekh - (eof-maclen) payload data
+eokb - +4   MSB length of encryption key hash
++4   - ekh  encryption key hash
+ekh  - (eof-macl)  payload data
+macl - eof  message integrity tag
 ```
 
 ## Decryption Script

--- a/docs/core/design/dcrypt.md
+++ b/docs/core/design/dcrypt.md
@@ -3,6 +3,12 @@ layout: doc
 title: lib-dcrypt
 dovecotlinks:
   lib_dcrypt: lib-dcrypt
+  lib_dcrypt_key_formats:
+    hash: key-formats
+    text: "lib-dcrypt: Key Formats"
+  lib_dcrypt_flags:
+    hash: flags
+    text: "lib-dcrypt: Flags"
 ---
 
 # lib-dcrypt
@@ -16,55 +22,55 @@ alternative backends for dcrypt.
 
 ECDH (Elliptic curve Diffie-Hellman) is widely used in lib-dcrypt for
 both key and data storage. This algorithm is also known as
-[ECIES (Elliptic Curve Integrated Encryption Scheme)](https://en.wikipedia.org/wiki/ECIES).
+[ECIES (Elliptic Curve Integrated Encryption Scheme)][ECIES].
 
 When encrypting data, we perform following steps, this is the currently
 used algorithm. There is also a legacy algorithm, but since that has not
 been used publicly, we do not describe it here. You can deduce it from
 the code if you want to.
 
-`ENCRYPT(RECIPIENT-KEY, DATA)`:
+### `ENCRYPT(RECIPIENT-KEY, DATA)`
 
 1. Ensure recipient key is not point at infinity
 
-2. Generate new keypair from same group
+1. Generate new keypair from same group
 
-3. Choose ephemeral public key as `R`
+1. Choose ephemeral public key as `R`
 
-4. Calculate $P = R * RECIPIENT-KEY$
+1. Calculate $P = R * RECIPIENT-KEY$
 
-5. From $P = (x,y)$ choose `x` as `S`
+1. From $P = (x,y)$ choose `x` as `S`
 
-6. Generate random IV+key and HMAC seed or AAD as encryption key material
+1. Generate random IV+key and HMAC seed or AAD as encryption key material
 
-7. Use $PBKDF2(mac-algorithm, S, salt, rounds)$ to produce IV+key, and AAD if used by cipher algorithm for encrypting the encryption key
+1. Use $PBKDF2(mac-algorithm, S, salt, rounds)$ to produce IV+key, and AAD if used by cipher algorithm for encrypting the encryption key
 
-8. Encrypt encryption key material with the values generated in step 7
+1. Encrypt encryption key material with the values generated in step 7
 
-8. Encrypt data using encryption key material
+1. Encrypt data using encryption key material
 
-9. OUTPUT R, salt and encrypted data.
+1. OUTPUT R, salt and encrypted data.
 
 In dcrypt-openssl.c, we use `EVP_PKEY_derive_*` for the actual
 derivations. ephemeral public key is exported with EC_POINT_point2oct in
 compressed form.
 
-`DECRYPT(PRIVATE-KEY, R, SALT, DATA)`:
+### `DECRYPT(PRIVATE-KEY, R, SALT, DATA)`
 
 1. Ensure R is not point at infinity
 
-2. Calculate $P = R * PRIVATE-KEY$
+1. Calculate $P = R * PRIVATE-KEY$
 
-3. From $P = (x,y)$ choose x as S
+1. From $P = (x,y)$ choose x as S
 
-4. Use $PBKDF2(mac-algorithm, S, salt, rounds)$ to produce IV+key, and HMAC seed or
+1. Use $PBKDF2(mac-algorithm, S, salt, rounds)$ to produce IV+key, and HMAC seed or
    AAD for encryption key decryption
 
-5. Decrypt encryption key (if you are using GCM, AAD and TAG need to provided for encryption key decryption)
+1. Decrypt encryption key (if you are using GCM, AAD and TAG need to provided for encryption key decryption)
 
-6. Decrypt data using encryption key
+1. Decrypt data using encryption key
 
-6. OUTPUT decrypted data
+1. OUTPUT decrypted data
 
 ## Key Formats
 
@@ -100,7 +106,7 @@ Currently supported flags are:
  - 0x02 - Use AEAD for key and data integrity
  - 0x04 - No data integrity verification
  - 0x08 - Encrypted using obsolete version 1 algorithm
- - 0x10 - Use same cipher algorithm for key and data, [[added,dcrypt_same_cipher_algo_added]]
+ - 0x10 - Use same cipher algorithm for key and data [[added,dcrypt_same_cipher_algo_added]]
 
 ## File Format
 
@@ -109,7 +115,7 @@ asymmetric key pair. File encryption can be done using whatever
 algorithm(s) the underlying library supports. For integrity support,
 either HMAC based or AEAD based system is used when requested.
 
-File format is described below
+File format 2 is described below
 
 ```
 000 - 008 CRYPTED\x03\x07 (MAGIC)
@@ -134,5 +140,10 @@ eokb - +4  MSB length of encryption key hash
 ekh - (eof-maclen) payload data
 ```
 
+## Decryption Script
+
 There is a small script for decrypting these files, see
-[`dcrypt-decrypt.rb`](https://github.com/dovecot/tools/blob/main/dcrypt-decrypt.rb).
+[`dcrypt-decrypt.py`][dcrypt-decrypt].
+
+[ECIES]: https://en.wikipedia.org/wiki/ECIES
+[dcrypt-decrypt]: https://github.com/dovecot/tools/blob/main/dcrypt-decrypt.py


### PR DESCRIPTION
- Cleanup page,
- amend file format 2 description and
- add exhausting documentation for the new `dcrypt-decrypt.py` script. (Which depending on review might not yet be fully published.)

Closes DOV-7024.