### PR TITLE
DOV-6869: Link release notes for 3.1

### DIFF
--- a/docs/core/settings/syntax.md
+++ b/docs/core/settings/syntax.md
@@ -11,6 +11,9 @@ dovecotlinks:
   settings_connection_filters:
     hash: connection-filters
     text: Connection Filters
+  settings_groups_includes:
+    hash: groups-includes
+    text: Groups Includes
 ---
 
 # Dovecot Config File Syntax


### PR DESCRIPTION
Add necessary reference to allow linking into the release notes.

Closes DOV-6869.