### PR TITLE
DOV-7357: Fix doveconf manpage

### DIFF
--- a/docs/core/man/doveconf.1.md
+++ b/docs/core/man/doveconf.1.md
@@ -26,10 +26,11 @@ dovecotComponent: core
 
 ## DESCRIPTION
 
-**doveconf** reads and parses Dovecot's configuration files and converts
-them into a simpler format used by the rest of Dovecot. All standalone
-programs, such as [[man,dovecot]], will first get their settings by executing
-doveconf.
+**doveconf** reads and parses Dovecot's configuration files and converts them
+into a simpler format used by the rest of Dovecot.
+
+All standalone programs, such as [[man,dovecot]], will first get their settings
+by executing doveconf.
 
 For system administrators, **doveconf** is mainly useful for dumping the
 configuration in easy human readable output.

--- a/docs/core/man/doveconf.1.md
+++ b/docs/core/man/doveconf.1.md
@@ -30,7 +30,8 @@ dovecotComponent: core
 into a simpler format used by the rest of Dovecot.
 
 All standalone programs, such as [[man,dovecot]], will first get their settings
-by executing doveconf.
+by executing doveconf, unless they can get the settings by connecting to the
+config UNIX socket.
 
 For system administrators, **doveconf** is mainly useful for dumping the
 configuration in easy human readable output.


### PR DESCRIPTION
- Remove the unsupported `-f` parameter,
- rewrite description to fix formatting issues.

Closes DOV-7357.