### PR TITLE
global: Rename local_validation to oauth2_local_validation

### DIFF
--- a/data/settings.js
+++ b/data/settings.js
@@ -9055,7 +9055,7 @@ A dictionary for fetching validation keys.
 Example:
 
 \`\`\`[dovecot.conf]
-local_validation {
+oauth2_local_validation {
   dict fs {
     fs posix {
       prefix = /tmp/keys/

--- a/docs/core/config/auth/databases/oauth2.md
+++ b/docs/core/config/auth/databases/oauth2.md
@@ -227,7 +227,7 @@ To use local validation, put into `dovecot.conf`:
 ```[dovecot.conf]
 oauth2 {
   introspection_mode = local
-  local_validation {
+  oauth2_local_validation {
     dict fs {
       fs posix {
         prefix=/etc/dovecot/keys/


### PR DESCRIPTION
The oauth2_ prefix wasn't originally needed when it was under oauth2 {} but that ended up causing issues elsewhere, so now it's needed.