### PR TITLE
 howto/exim, upgrade: Use auth-legacy socket type for Exim authentication 

### DIFF
--- a/docs/howto/sasl/exim.md
+++ b/docs/howto/sasl/exim.md
@@ -1,5 +1,5 @@
 ---
-layout: doct
+layout: doc
 title: Exim and Dovecot SASL
 dovecotlinks:
   howto_exim_and_dovecot_sasl: Exim and Dovecot SASL

--- a/docs/howto/sasl/exim.md
+++ b/docs/howto/sasl/exim.md
@@ -19,7 +19,9 @@ auth_mechanisms = plain login
 service auth {
   ...
   # SASL
-  unix_listener auth-client {
+  unix_listener auth-exim {
+    # Exim requires legacy auth type until it gets updated
+    type = auth-legacy
     mode = 0660
     user = mail
   }
@@ -31,7 +33,7 @@ service auth {
 dovecot_login:
   driver = dovecot
   public_name = LOGIN
-  server_socket = /var/run/dovecot/auth-client
+  server_socket = /var/run/dovecot/auth-exim
   # setting server_set_id might break several headers in mails sent by
   # authenticated smtp. So be careful.
   server_set_id = $auth1
@@ -39,7 +41,7 @@ dovecot_login:
 dovecot_plain:
   driver = dovecot
   public_name = PLAIN
-  server_socket = /var/run/dovecot/auth-client
+  server_socket = /var/run/dovecot/auth-exim
   server_set_id = $auth1
 ```
 :::

--- a/docs/installation/upgrade/2.3-to-2.4.md
+++ b/docs/installation/upgrade/2.3-to-2.4.md
@@ -127,4 +127,6 @@ setup.
 
 <!-- @include: include/2.4-doveadm.inc -->
 
+<!-- @include: include/2.4-exim.inc -->
+
 <!-- @include: include/2.4-other.inc -->

--- a/docs/installation/upgrade/include/2.4-exim.inc
+++ b/docs/installation/upgrade/include/2.4-exim.inc
@@ -1,0 +1,21 @@
+
+### Exim Authentication
+
+Dovecot authentication protocol changed slightly, which is now causing Exim's
+Dovecot authentication to hang. Use the `auth-legacy` listener type to work
+around it until Exim supports the updated protocol:
+
+::: code-group
+```[dovecot.conf]
+service auth {
+  unix_listener auth-exim {
+    type = auth-legacy
+  }
+}
+```
+
+```[exim.conf]
+dovecot_plain:
+  server_socket = /var/run/dovecot/auth-exim
+  ...
+:::


### PR DESCRIPTION
DOV-7386