### PR TITLE
quota, howto: Specify quota_storage_size outside quota root in examples

### DIFF
--- a/docs/core/plugins/quota.md
+++ b/docs/core/plugins/quota.md
@@ -79,8 +79,11 @@ protocol imap {
   }
 }
 
+# Keep this setting outside the quota { .. } to allow easily overriding it
+# in userdb lookups.
+quota_storage_size = 1G
+
 quota "User quota" {
-  quota_storage_size = 1G
 }
 ```
 
@@ -330,9 +333,10 @@ protocol !indexer-worker {
   mail_vsize_bg_after_count = 100
 }
 
+# 10MB quota limit
+quota_storage_size = 10M
+
 quota "User quota" {
-  # 10MB quota limit
-  quota_storage_size = 10M
 }
 ```
 

--- a/docs/howto/virtual/postfix.md
+++ b/docs/howto/virtual/postfix.md
@@ -190,8 +190,8 @@ protocol lmtp {
 
 ::: code-group
 ```[dovecot.conf]
+quota_storage_size = 1GB
 quota user {
-  quota_storage_size = 1GB
 }
 mailbox Trash {
   quota_storage_percentage = 110


### PR DESCRIPTION
Otherwise it can't be easily overridden by userdb.