### PR TITLE
global-options-formatter: Mention 'json' option

### DIFF
--- a/docs/core/man/include/global-options-formatter.inc
+++ b/docs/core/man/include/global-options-formatter.inc
@@ -7,6 +7,9 @@
     **flow**
     :    prints each line with *key*<!-- -->**=**<!-- -->*value* pairs.
 
+    **json**
+    :    prints a JSON array of JSON objects.
+
     **pager**
     :    prints each *key*: *value* pair on its own line and separates
          records with form feed character (**^L**).


### PR DESCRIPTION
If I'm reading https://github.com/dovecot/core/blob/1b8098aa7880ee50f401c8756195f47574f163eb/src/doveadm/doveadm-print-json.c correctly, the JSON format is always going to be an array of objects, so I added that detail.

Closes #1239.