### PR TITLE
github: Separate 2.3 and 2.4 release workflows

### DIFF
--- a/.github/workflows/2_3.yml
+++ b/.github/workflows/2_3.yml
@@ -1,0 +1,27 @@
+name: Deploy 2.3
+
+on:
+  push:
+    branches:
+      - release-2.3
+    tags:
+      - '2.3.*'
+
+jobs:
+  release_2_3:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/release-2.3'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dovecot/dovecot-sphinx-action@0.11
+    - uses: dovecot/rsync-deployments@v2.0.2
+      with:
+        FLAGS: -azr --delete
+        HOST: doc.dovecot.org
+        USER: docs
+        LOCALPATH: /build/.
+        REMOTEPATH: public_html/2.3
+        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      if: env.DEPLOY_KEY
+      env:
+        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,14 @@
-name: Deploy main
+name: Deploy 2.4
 
 on:
   push:
     branches:
       - main
-      - release-2.3
     tags:
-      - '2.*'
+      - '2.4.*'
 
 jobs:
-  releasenew:
+  release_2_4:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -70,9 +69,9 @@ jobs:
       with:
         name: documentation-tar
         path: tars/docs.tgz
-  publishnew:
+  publish_2_4:
     runs-on: ubuntu-latest
-    needs: releasenew
+    needs: release_2_4
     if: github.ref == 'refs/heads/main'
     name: Publish documentation tarball
     steps:
@@ -99,20 +98,3 @@ jobs:
         files: |
           ./SHA256SUMS.txt
           ./docs.tgz
-  release23:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/release-2.3'
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dovecot/dovecot-sphinx-action@0.11
-    - uses: dovecot/rsync-deployments@v2.0.2
-      with:
-        FLAGS: -azr --delete
-        HOST: doc.dovecot.org
-        USER: docs
-        LOCALPATH: /build/.
-        REMOTEPATH: public_html/2.3
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-      if: env.DEPLOY_KEY
-      env:
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
2.3 release would build all of vitepress documentation even though it is never used.

Regardless, given EOL of 2.3, it should be removed from the "main" release action anyway.