### PR TITLE
Fix typo in userdb_ldap_iterate_fields

### DIFF
--- a/data/settings.js
+++ b/data/settings.js
@@ -11520,7 +11520,7 @@ Example:
 \`\`\`
 userdb ldap {
   iterate_filter = (objectClass=smiMessageRecipient)
-  iterate_attrs {
+  iterate_fields {
     user = %{ldap:mailRoutingAddress}
   }
 }
@@ -11536,7 +11536,7 @@ Filter to get a list of all users.
 \`\`\`
 userdb ldap {
   iterate_filter = (objectClass=smiMessageRecipient)
-  iterate_attrs {
+  iterate_fields {
     user = %{ldap:mailRoutingAddress}
   }
 }


### PR DESCRIPTION
Documentation incorrectly uses nonexistent `userdb_ldap_iterate_attrs` instead of `userdb_ldap_iterate_fields` in examples.