### PR TITLE
docs: fix vertical bar symbol breaking table layout

### DIFF
--- a/docs/core/config/mail_location.md
+++ b/docs/core/config/mail_location.md
@@ -28,8 +28,8 @@ See [[variable]] for a full list, but the most commonly used ones are:
 | Variable | Description |
 | -------- | ----------- |
 | `%{user}` | Full username. |
-| `%{user | username}` | User part in `user@domain`; same as `%{user}` if there's no domain. |
-| `%{user | domain}` | Domain part in `user@domain`; empty if there's no domain. |
+| `%{user \| username}` | User part in `user@domain`; same as `%{user}` if there's no domain. |
+| `%{user \| domain}` | Domain part in `user@domain`; empty if there's no domain. |
 
 ### Directory Hashing
 


### PR DESCRIPTION
The issue on "[Mail Location](https://doc.dovecot.org/2.4.2/core/config/mail_location.html#variables)":

<img width="758" height="396" alt="vertical bar symbol breaking table layout" src="https://github.com/user-attachments/assets/8c8d90b8-0ec9-4ab8-8607-e0a18357a5e9" />