### PR TITLE
Exclude all files not in docs/ from being processed

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -49,7 +49,12 @@ export default defineConfig({
 	lang: "en-us",
 
 	srcDir: ".",
-	srcExclude: [ '*.md' ].concat(getExcludes()),
+	srcExclude: [
+		// Exclude anything that is not in docs
+		'!(docs)/**/*.md',
+		// Exclude base-level markdown files
+		'*.md'
+	].concat(getExcludes()),
 	rewrites: {
 		'docs/:path(.*)': ':path',
 	},


### PR DESCRIPTION
Removes one unneeded file from the built site (assets/plantuml/README.md), and prevents these kind of files from being added in the future.x