### PR TITLE
navbar: Allow versions.json to work for both development and producti…

### DIFF
--- a/lib/navbar.js
+++ b/lib/navbar.js
@@ -1,9 +1,17 @@
 import { withBase } from 'vitepress'
 
+// Allows versions.json to be tested locally (in development mode)
+// by placing in public/ folder.
+// Otherwise, in production, file is always located at webroot.
+const VERSIONS_PATH = import.meta.env.DEV
+	? withBase('versions.json')
+	: '/versions.json'
+
 // Populate the version list in the navbar
 export async function navbarAddVersions() {
 	try {
-		const response = await fetch(withBase('versions.json'))
+		// Cache buster updates once-a-day based on local user timezone
+		const response = await fetch(`${VERSIONS_PATH}?t=${new Date().setHours(0, 0, 0, 0)}`)
 		if (!response.ok) return
 
 		const data = await response.json()


### PR DESCRIPTION
…on mode

Locally, versions.json needs to live in base path to work correctly. This allows the code to work automatically in both modes.

Add a cache buster to ensure the versions file is updated once a day.

JIRA: DOV-9080