### PR TITLE
CLONE 3.1: navbar: Dynamically inject versions into mobile view list

### DIFF
--- a/lib/navbar.js
+++ b/lib/navbar.js
@@ -16,26 +16,52 @@ export async function navbarAddVersions() {
 
 		const data = await response.json()
 
-		const navbar = document.querySelector('.VPNavBarMenuGroup')
-		if (!navbar) throw new Error("Missing DOM navbar element")
-		const listNode = navbar.querySelector('.menu .items')
-		const refNode = listNode.querySelector('.VPMenuLink')
+		// Reusable function to populate DOM menu lists
+		function populateList(navbar, listClass, refClass, textSelector) {
+			if (!navbar) return
+			const listNode = navbar.querySelector(listClass)
+			if (!listNode) return
+			const refNode = listNode.querySelector(refClass)
+			const textNode = navbar.querySelector(textSelector)
+			if (!refNode || !textNode) return
+
+			const currVers = textNode.innerText.trim()
+			const existingLinks = Array.from(listNode.querySelectorAll('a'))
+				.map(a => a.textContent.trim())
+
+			versions.forEach((version) => {
+				if (version === currVers || existingLinks.includes(version)) return
+
+				const entry = refNode.cloneNode(true)
+				const anchor = entry.querySelector('a')
+
+				anchor.href = `/${version}/`
+				anchor.textContent = version
+
+				listNode.prepend(entry)
+			})
+		}
 
 		// Ensure 'main' is present and remove duplicates
 		const versions = [...new Set([...data, 'main'])]
-		const currVers = navbar.querySelector('button span.text').innerText.trim()
 
-		versions.forEach((version) => {
-			if (version === currVers) return
+		const navbar = document.querySelector('.VPNavBarMenuGroup')
+		if (!navbar) throw new Error("Missing DOM navbar element")
+		populateList(navbar, '.menu .items', '.VPMenuLink', 'button span.text')
 
-			const entry = refNode.cloneNode(true)
-			const anchor = entry.querySelector('a')
-
-			anchor.href = `/${version}/`
-			anchor.textContent = version
-
-			listNode.prepend(entry)
-		})
+		// Setup MutationObserver to watch for mobile NavScreen opening
+		new MutationObserver((m) => {
+			for (const mutation of m) {
+				for (const node of mutation.addedNodes) {
+					if (node instanceof Element && node.classList.contains('VPNavScreen')) {
+						populateList(node.querySelector('.VPNavScreenMenuGroup'), '.items', '.item', '.button-text')
+					}
+				}
+			}
+		}).observe(
+			navbar.closest('HEADER.VPNav'),
+			{ childList: true, subtree: true }
+		)
 	} catch (error) {
 		console.error('Failed to inject version dropdown:', error)
 	}


### PR DESCRIPTION
VitePress's mobile navigation screen is dynamically generated by Vue rather than being present in the DOM statically, and its reactive config (`useData().theme`) is read-only.

Thus, we need to populate this dynamic DOM element when it is created so that the version list appears correctly in the mobile (small-screen) view.