### PR TITLE
docs(core.config.auth.databases.ldap): fix LDAP filter config variable

### DIFF
--- a/docs/core/config/auth/databases/ldap.md
+++ b/docs/core/config/auth/databases/ldap.md
@@ -475,7 +475,7 @@ ldap_base = dc=example,dc=org
 userdb ldap-user {
   driver = ldap
   result_success = continue-ok
-  ldap_filter = (&(objectClass=posixAccount)(uid=%{user}))
+  filter = (&(objectClass=posixAccount)(uid=%{user}))
   fields {
     class = %{ldap:userClass}
   }
@@ -484,7 +484,7 @@ userdb ldap-user {
 userdb ldap-class {
   driver = ldap
   skip = notfound
-  ldap_filter = (&(objectClass=classSettings)(class=%{userdb:class}))
+  filter = (&(objectClass=classSettings)(class=%{userdb:class}))
   fields {
     quota_storage_size = %{ldap:quotaBytes}B
   }


### PR DESCRIPTION
Hello,
https://doc.dovecot.org/2.4.4/core/config/auth/databases/ldap.html#ldap-userdb

documents two variants to specify the LDAP filter:
```
userdb ldap {
  filter = (&(objectClass=posixAccount)(uid=%{user}))
  fields {
    home = %{ldap:homeDirectory}
    uid = %{ldap:uidNumber}
    gid = %{ldap:gidNumber}
  }
}
```

```
userdb ldap-user {
  driver = ldap
  result_success = continue-ok
  ldap_filter = (&(objectClass=posixAccount)(uid=%{user}))
  fields {
    class = %{ldap:userClass}
  }
}
```

either as `filter` or as `ldap_filter`.
I didn't find the source code, where this is parsed.
But I assume `ldap_filter` in a userdb/passwd block is wrong. Only the global options are prefixed with `ldap_`.