### PR TITLE
core/plugins/quota: warn that a block-scoped limit shadows userdb overrides

### DIFF
--- a/docs/core/plugins/quota.md
+++ b/docs/core/plugins/quota.md
@@ -144,6 +144,14 @@ settings you need to in your userdb.
 Use [[doveadm,user]] command to verify that the userdb returns the expected
 quota settings.
 
+::: warning
+A userdb override replaces the top-level [[setting,quota_storage_size]] only.
+If the limit is declared inside a named `quota { .. }` block, the block-scoped
+value shadows the override, which is then silently ignored — even though
+[[doveadm,user]] still echoes the field back. To override a block-scoped
+limit, address the block by name: `userdb_quota/<name>/storage_size=100M`.
+:::
+
 #### Override: LDAP
 
 Example [[link,auth_ldap]] where the quota limit is in `quotaBytes` field:


### PR DESCRIPTION
The Per-User Quota examples override `quota_storage_size` from userdb, and the page's main example deliberately keeps that setting outside the `quota { .. }` block ("Keep this setting outside the quota { .. } to allow easily overriding it in userdb lookups"). What the page never states is what happens when the limit *is* declared inside the block: the block-scoped value shadows the flat userdb override, which is then silently ignored — while `doveadm user`, which this section recommends for verification, still echoes the field back as if it had taken effect.

Measured on stock 2.4.4 with a passwd-file userdb, both directions: `userdb_quota_storage_size=100M` overrides a top-level `quota_storage_size = 1G` and is ignored when the limit is declared inside a named block; `userdb_quota/<name>/storage_size` addresses the block-scoped limit.

This trips users migrating from 2.3, where the limit commonly lived inside `plugin { quota_rule = ... }` — see e.g. [Quota plugin: "quota_storage_size" not recognized from userdb extra fields in dovecot 2.4.1](https://dovecot.org/mailman3/archives/list/dovecot@dovecot.org/thread/67DBLLW4L5QBTEYRKGA26POFZ52ZR7ZO/) on the mailing list.

This adds a warning box to the Per-User Quota section naming the failure mode and the path form that addresses a block-scoped limit.